### PR TITLE
reduce compile time of TimeInterval extension (14s -> 92ms)

### DIFF
--- a/LeadKit/Sources/Extensions/TimeInterval/TimeInterval+DateComponents.swift
+++ b/LeadKit/Sources/Extensions/TimeInterval/TimeInterval+DateComponents.swift
@@ -42,14 +42,21 @@ extension TimeInterval {
      */
     public init(timeString: String, timeSeparator: String = ":", daySeparator: String = ".") {
         let timeComponents = timeString.components(separatedBy: daySeparator)
-        let fullDays = Double(timeComponents.first ?? "") ?? 0
 
-        let timeValue = (timeComponents.last ?? "")
+        let dayComponent = timeComponents.first ?? ""
+
+        let fullDays = Double(dayComponent) ?? 0
+
+        let timeComponent = timeComponents.last ?? ""
+
+        let timeValue = timeComponent
             .components(separatedBy: timeSeparator)
             .reversed()
             .enumerated()
-            .reduce(0) { interval, part in
-                interval + (Double(part.element) ?? 0) * pow(Double(TimeInterval.secondsInMinute), Double(part.offset))
+            .reduce(0.0) { interval, part in
+                let partElement = Double(part.element) ?? 0
+
+                return interval + partElement * pow(Double(TimeInterval.secondsInMinute), Double(part.offset))
         }
 
         self = (fullDays * Double(TimeInterval.secondsInDay)) + timeValue


### PR DESCRIPTION
<img width="1111" alt="screen shot 2017-05-16 at 12 34 39" src="https://cloud.githubusercontent.com/assets/6436245/26100115/a0e85640-3a35-11e7-9beb-48bae0658c48.png">
<img width="1111" alt="screen shot 2017-05-16 at 12 40 41" src="https://cloud.githubusercontent.com/assets/6436245/26100116/a0e88764-3a35-11e7-86fe-41b1f63b12e2.png">
