### PR TITLE
Feature/additions merge

### DIFF
--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -39,6 +39,9 @@ Pod::Spec.new do |s|
     ss.watchos.deployment_target = '2.0'
 
     ss.source_files = "Sources/**/*.swift"
+    ss.ios.exclude_files = [
+      "Sources/Extensions/NetworkService/NetworkService+ActivityIndicator.swift",
+    ]
     ss.watchos.exclude_files = [
       "Sources/Classes/Views/SeparatorRowBox/*",
       "Sources/Classes/Views/SeparatorCell/*",
@@ -49,7 +52,7 @@ Pod::Spec.new do |s|
       "Sources/Classes/Views/DefaultPlaceholders/*",
       "Sources/Extensions/CABasicAnimation/*",
       "Sources/Extensions/CGFloat/CGFloat+Pixels.swift",
-      "Sources/Extensions/NetworkService/NetworkService+ActivityIndicator.swift",
+      "Sources/Extensions/NetworkService/NetworkService+ActivityIndicator-UIApplication.swift",
       "Sources/Extensions/NetworkService/NetworkService+RxLoadImage.swift",
       "Sources/Extensions/DataLoading/GeneralDataLoading/GeneralDataLoadingController+DefaultImplementation.swift",
       "Sources/Extensions/DataLoading/PaginationDataLoading/*",
@@ -80,7 +83,7 @@ Pod::Spec.new do |s|
       "Sources/Classes/Views/EmptyCell/*",
       "Sources/Classes/DataLoading/PaginationDataLoading/PaginationWrapper.swift",
       "Sources/Structures/Drawing/CALayerDrawingOperation.swift",
-      "Sources/Extensions/NetworkService/NetworkService+ActivityIndicator.swift",
+      "Sources/Extensions/NetworkService/NetworkService+ActivityIndicator-UIApplication.swift",
       "Sources/Extensions/DataLoading/PaginationDataLoading/*",
       "Sources/Extensions/Support/UIScrollView+Support.swift",
       "Sources/Extensions/TableDirector/*",

--- a/LeadKit.xcodeproj/project.pbxproj
+++ b/LeadKit.xcodeproj/project.pbxproj
@@ -245,7 +245,7 @@
 		671463981EB3396E00EAB194 /* AnyLoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671462431EB3396E00EAB194 /* AnyLoadingIndicator.swift */; };
 		671463991EB3396E00EAB194 /* AnyLoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671462431EB3396E00EAB194 /* AnyLoadingIndicator.swift */; };
 		6714639B1EB3396E00EAB194 /* AnyLoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671462431EB3396E00EAB194 /* AnyLoadingIndicator.swift */; };
-		6714639E1EB33AEB00EAB194 /* NetworkService+ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6714639D1EB33AEB00EAB194 /* NetworkService+ActivityIndicator.swift */; };
+		6714639E1EB33AEB00EAB194 /* NetworkService+ActivityIndicator-UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6714639D1EB33AEB00EAB194 /* NetworkService+ActivityIndicator-UIApplication.swift */; };
 		671463A21EB33FF600EAB194 /* Animatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671463A11EB33FF600EAB194 /* Animatable.swift */; };
 		671463A31EB33FF600EAB194 /* Animatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671463A11EB33FF600EAB194 /* Animatable.swift */; };
 		671463A41EB33FF600EAB194 /* Animatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671463A11EB33FF600EAB194 /* Animatable.swift */; };
@@ -385,6 +385,17 @@
 		67A1FF941EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A1FF931EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift */; };
 		67A1FF951EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A1FF931EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift */; };
 		67A1FF971EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A1FF931EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift */; };
+		67CAF8AC2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8AB2065189C00527085 /* NetworkService+ActivityIndicator.swift */; };
+		67CAF8AD2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8AB2065189C00527085 /* NetworkService+ActivityIndicator.swift */; };
+		67CAF8AE2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8AB2065189C00527085 /* NetworkService+ActivityIndicator.swift */; };
+		67CAF8B120651E1E00527085 /* ConfigurableNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8B020651E1E00527085 /* ConfigurableNetworkService.swift */; };
+		67CAF8B220651E1E00527085 /* ConfigurableNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8B020651E1E00527085 /* ConfigurableNetworkService.swift */; };
+		67CAF8B320651E1E00527085 /* ConfigurableNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8B020651E1E00527085 /* ConfigurableNetworkService.swift */; };
+		67CAF8B420651E1E00527085 /* ConfigurableNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8B020651E1E00527085 /* ConfigurableNetworkService.swift */; };
+		67CAF8B620651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8B520651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift */; };
+		67CAF8B720651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8B520651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift */; };
+		67CAF8B820651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8B520651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift */; };
+		67CAF8B920651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8B520651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift */; };
 		67CDEE401EB369BF00895905 /* ConfigurableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671462241EB3396E00EAB194 /* ConfigurableController.swift */; };
 		67E6C2351EBB32F5007842A6 /* SingleLoadCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E6C2341EBB32F5007842A6 /* SingleLoadCursor.swift */; };
 		67E6C2361EBB32F5007842A6 /* SingleLoadCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E6C2341EBB32F5007842A6 /* SingleLoadCursor.swift */; };
@@ -589,7 +600,7 @@
 		6714623F1EB3396E00EAB194 /* SolidFillDrawingOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SolidFillDrawingOperation.swift; sourceTree = "<group>"; };
 		671462401EB3396E00EAB194 /* TemplateDrawingOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TemplateDrawingOperation.swift; sourceTree = "<group>"; };
 		671462431EB3396E00EAB194 /* AnyLoadingIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyLoadingIndicator.swift; sourceTree = "<group>"; };
-		6714639D1EB33AEB00EAB194 /* NetworkService+ActivityIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NetworkService+ActivityIndicator.swift"; sourceTree = "<group>"; };
+		6714639D1EB33AEB00EAB194 /* NetworkService+ActivityIndicator-UIApplication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NetworkService+ActivityIndicator-UIApplication.swift"; sourceTree = "<group>"; };
 		671463A11EB33FF600EAB194 /* Animatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animatable.swift; sourceTree = "<group>"; };
 		671463A61EB340C000EAB194 /* UIViewController+ConfigurableController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+ConfigurableController.swift"; sourceTree = "<group>"; };
 		671463AE1EB34B1E00EAB194 /* StubCursor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubCursor.swift; sourceTree = "<group>"; };
@@ -645,6 +656,9 @@
 		679C77D61F98F7A60094BE10 /* UIAlertController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extensions.swift"; sourceTree = "<group>"; };
 		67A1FF8E1EBCA09B00D6C89F /* UIImage+Spinner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Spinner.swift"; sourceTree = "<group>"; };
 		67A1FF931EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CABasicAnimation+Rotation.swift"; sourceTree = "<group>"; };
+		67CAF8AB2065189C00527085 /* NetworkService+ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkService+ActivityIndicator.swift"; sourceTree = "<group>"; };
+		67CAF8B020651E1E00527085 /* ConfigurableNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableNetworkService.swift; sourceTree = "<group>"; };
+		67CAF8B520651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConfigurableNetworkService+DefaultImplementation.swift"; sourceTree = "<group>"; };
 		67E6C2341EBB32F5007842A6 /* SingleLoadCursor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleLoadCursor.swift; sourceTree = "<group>"; };
 		67EB7FBF206140E600BDD9FB /* TotalCountCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalCountCursor.swift; sourceTree = "<group>"; };
 		67EB7FC6206148D000BDD9FB /* TotalCountCursorListingResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalCountCursorListingResult.swift; sourceTree = "<group>"; };
@@ -1045,6 +1059,7 @@
 			isa = PBXGroup;
 			children = (
 				67EB7FC5206148C400BDD9FB /* DataLoading */,
+				67CAF8AF20651E0F00527085 /* NetworkService */,
 				673CF4202063D8EB00C329F6 /* Rx */,
 				67EB7FF5206175CD00BDD9FB /* Views */,
 				679C77D41F98F78E0094BE10 /* AlertRepresentable.swift */,
@@ -1113,7 +1128,9 @@
 		6714639C1EB33AC200EAB194 /* NetworkService */ = {
 			isa = PBXGroup;
 			children = (
-				6714639D1EB33AEB00EAB194 /* NetworkService+ActivityIndicator.swift */,
+				67CAF8B520651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift */,
+				6714639D1EB33AEB00EAB194 /* NetworkService+ActivityIndicator-UIApplication.swift */,
+				67CAF8AB2065189C00527085 /* NetworkService+ActivityIndicator.swift */,
 			);
 			path = NetworkService;
 			sourceTree = "<group>";
@@ -1344,6 +1361,14 @@
 				67A1FF931EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift */,
 			);
 			path = CABasicAnimation;
+			sourceTree = "<group>";
+		};
+		67CAF8AF20651E0F00527085 /* NetworkService */ = {
+			isa = PBXGroup;
+			children = (
+				67CAF8B020651E1E00527085 /* ConfigurableNetworkService.swift */,
+			);
+			path = NetworkService;
 			sourceTree = "<group>";
 		};
 		67EB7FC5206148C400BDD9FB /* DataLoading */ = {
@@ -2315,8 +2340,9 @@
 				673CF42C2063DE5900C329F6 /* TextPlaceholderView.swift in Sources */,
 				671463601EB3396E00EAB194 /* SupportProtocol.swift in Sources */,
 				671462841EB3396E00EAB194 /* CGContext+Initializers.swift in Sources */,
+				67CAF8B120651E1E00527085 /* ConfigurableNetworkService.swift in Sources */,
 				EFBE57DB1EC361620040E00A /* UIView+Layout.swift in Sources */,
-				6714639E1EB33AEB00EAB194 /* NetworkService+ActivityIndicator.swift in Sources */,
+				6714639E1EB33AEB00EAB194 /* NetworkService+ActivityIndicator-UIApplication.swift in Sources */,
 				A6E0DDEF1F8A6C57002CA74E /* CellSeparatorType.swift in Sources */,
 				6714634C1EB3396E00EAB194 /* ReuseIdentifierProtocol.swift in Sources */,
 				671462F01EB3396E00EAB194 /* UIImage+SupportExtensions.swift in Sources */,
@@ -2360,6 +2386,7 @@
 				671462581EB3396E00EAB194 /* Log.swift in Sources */,
 				671462781EB3396E00EAB194 /* ResizeMode.swift in Sources */,
 				A676AE551F98112E001F9214 /* ObservableMappable.swift in Sources */,
+				67CAF8B620651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift in Sources */,
 				A6E0DDE11F8A696F002CA74E /* SeparatorRowBox.swift in Sources */,
 				A6E0DDDE1F8A696F002CA74E /* EmptyCellRow.swift in Sources */,
 				67EB7FFD206176C900BDD9FB /* AnyPaginationWrappable.swift in Sources */,
@@ -2465,6 +2492,8 @@
 				671462821EB3396E00EAB194 /* AlamofireRequest+Extensions.swift in Sources */,
 				67745288206259CF0024EEEF /* Rx+RxDataSourceProtocol.swift in Sources */,
 				67E6C2371EBB32F5007842A6 /* SingleLoadCursor.swift in Sources */,
+				67CAF8B320651E1E00527085 /* ConfigurableNetworkService.swift in Sources */,
+				67CAF8B820651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift in Sources */,
 				671463561EB3396E00EAB194 /* StaticViewHeightProtocol.swift in Sources */,
 				6771DFE01EE99F6F002DCDAE /* DateFormattingArguments.swift in Sources */,
 				671463621EB3396E00EAB194 /* SupportProtocol.swift in Sources */,
@@ -2502,6 +2531,7 @@
 				671463721EB3396E00EAB194 /* ApiRequestParameters.swift in Sources */,
 				6714636E1EB3396E00EAB194 /* XibNameProtocol.swift in Sources */,
 				67CDEE401EB369BF00895905 /* ConfigurableController.swift in Sources */,
+				67CAF8AD2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */,
 				A676AE481F97D28A001F9214 /* String+Extensions.swift in Sources */,
 				673CF4242063D90600C329F6 /* DisposeBagHolder.swift in Sources */,
 				671462A21EB3396E00EAB194 /* Double+Rounding.swift in Sources */,
@@ -2575,6 +2605,7 @@
 				671463271EB3396E00EAB194 /* Any+TypeName.swift in Sources */,
 				67EB7FD220615B8900BDD9FB /* TotalCountCursorConfiguration.swift in Sources */,
 				EFBE57D31EC35EF20040E00A /* Array+Extensions.swift in Sources */,
+				67CAF8AE2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */,
 				6714638B1EB3396E00EAB194 /* RoundDrawingOperation.swift in Sources */,
 				67EB7FFF206176C900BDD9FB /* AnyPaginationWrappable.swift in Sources */,
 				A676AE4A1F97D28A001F9214 /* String+Extensions.swift in Sources */,
@@ -2635,6 +2666,7 @@
 				675C1FB41F97CA32007D5249 /* AppearanceConfigurable.swift in Sources */,
 				6714631B1EB3396E00EAB194 /* UIWindow+Extensions.swift in Sources */,
 				671462571EB3396E00EAB194 /* App.swift in Sources */,
+				67CAF8B420651E1E00527085 /* ConfigurableNetworkService.swift in Sources */,
 				673CF4252063D90600C329F6 /* DisposeBagHolder.swift in Sources */,
 				6714637B1EB3396E00EAB194 /* CALayerDrawingOperation.swift in Sources */,
 				6774529520625D170024EEEF /* GeneralDataLoadingModel.swift in Sources */,
@@ -2649,6 +2681,7 @@
 				6774529020625C9E0024EEEF /* GeneralDataLoadingState.swift in Sources */,
 				67EB7FC3206140E600BDD9FB /* TotalCountCursor.swift in Sources */,
 				6714638F1EB3396E00EAB194 /* SolidFillDrawingOperation.swift in Sources */,
+				67CAF8B920651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift in Sources */,
 				67E6C2381EBB32F5007842A6 /* SingleLoadCursor.swift in Sources */,
 				671462531EB3396E00EAB194 /* StaticCursor.swift in Sources */,
 				6714629F1EB3396E00EAB194 /* CursorType+Slice.swift in Sources */,
@@ -2768,6 +2801,7 @@
 				671462551EB3396E00EAB194 /* App.swift in Sources */,
 				67A1FF901EBCA09B00D6C89F /* UIImage+Spinner.swift in Sources */,
 				6774529B20625E5B0024EEEF /* PaginationDataLoadingState.swift in Sources */,
+				67CAF8B220651E1E00527085 /* ConfigurableNetworkService.swift in Sources */,
 				671463791EB3396E00EAB194 /* CALayerDrawingOperation.swift in Sources */,
 				6714632D1EB3396E00EAB194 /* ConfigurableController.swift in Sources */,
 				67745287206259CF0024EEEF /* Rx+RxDataSourceProtocol.swift in Sources */,
@@ -2783,9 +2817,11 @@
 				671463A31EB33FF600EAB194 /* Animatable.swift in Sources */,
 				6771DFE51EE9A00A002DCDAE /* DateFormattingArguments+DateFormatter.swift in Sources */,
 				671462511EB3396E00EAB194 /* StaticCursor.swift in Sources */,
+				67CAF8B720651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift in Sources */,
 				6714629D1EB3396E00EAB194 /* CursorType+Slice.swift in Sources */,
 				671463691EB3396E00EAB194 /* ConfigurableView.swift in Sources */,
 				67EB7FD020615B8900BDD9FB /* TotalCountCursorConfiguration.swift in Sources */,
+				67CAF8AC2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LeadKit.xcodeproj/project.pbxproj
+++ b/LeadKit.xcodeproj/project.pbxproj
@@ -2462,6 +2462,7 @@
 				671462481EB3396E00EAB194 /* FixedPageCursor.swift in Sources */,
 				671462C81EB3396E00EAB194 /* String+Localization.swift in Sources */,
 				671462B81EB3396E00EAB194 /* Sequence+ConcurrentMap.swift in Sources */,
+				67C7B1792068BB1C00C9EDA3 /* NumberFormattingService.swift in Sources */,
 				671463741EB3396E00EAB194 /* BorderDrawingOperation.swift in Sources */,
 				A676AE4B1F97D28A001F9214 /* String+Extensions.swift in Sources */,
 				6714633C1EB3396E00EAB194 /* LoadingIndicator.swift in Sources */,

--- a/LeadKit.xcodeproj/project.pbxproj
+++ b/LeadKit.xcodeproj/project.pbxproj
@@ -1077,7 +1077,6 @@
 				67EB7FC5206148C400BDD9FB /* DataLoading */,
 				67CAF8AF20651E0F00527085 /* NetworkService */,
 				673CF4202063D8EB00C329F6 /* Rx */,
-				67EB7FF5206175CD00BDD9FB /* Views */,
 				679C77D41F98F78E0094BE10 /* AlertRepresentable.swift */,
 				671463A11EB33FF600EAB194 /* Animatable.swift */,
 				40F118461F8FEF97004AADAF /* AppearanceConfigurable.swift */,
@@ -1452,13 +1451,6 @@
 				67EB7FF02061682F00BDD9FB /* TotalCountCursorListingResult+DefaultTotalCountCursorListingResult.swift */,
 			);
 			path = Cursors;
-			sourceTree = "<group>";
-		};
-		67EB7FF5206175CD00BDD9FB /* Views */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Views;
 			sourceTree = "<group>";
 		};
 		78CFEE201C5C456B00F50370 = {

--- a/LeadKit.xcodeproj/project.pbxproj
+++ b/LeadKit.xcodeproj/project.pbxproj
@@ -276,6 +276,14 @@
 		671463CF1EB34B1E00EAB194 /* TestView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 671463B71EB34B1E00EAB194 /* TestView.xib */; };
 		67186B311EB248F100CFAFFB /* LeadKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67186B281EB248F100CFAFFB /* LeadKit.framework */; };
 		67186B3F1EB24A1900CFAFFB /* LeadKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 67186B201EB247A200CFAFFB /* LeadKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		673564F12068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673564F02068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift */; };
+		673564F22068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673564F02068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift */; };
+		673564F32068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673564F02068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift */; };
+		673564F42068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673564F02068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift */; };
+		673564F62068C68D00F0CBED /* NumberFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673564F52068C68D00F0CBED /* NumberFormat.swift */; };
+		673564F72068C68D00F0CBED /* NumberFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673564F52068C68D00F0CBED /* NumberFormat.swift */; };
+		673564F82068C68D00F0CBED /* NumberFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673564F52068C68D00F0CBED /* NumberFormat.swift */; };
+		673564F92068C68D00F0CBED /* NumberFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673564F52068C68D00F0CBED /* NumberFormat.swift */; };
 		673CF40B2063AB7C00C329F6 /* GeneralDataLoadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CF40A2063AB7C00C329F6 /* GeneralDataLoadingViewModel.swift */; };
 		673CF40C2063AB7C00C329F6 /* GeneralDataLoadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CF40A2063AB7C00C329F6 /* GeneralDataLoadingViewModel.swift */; };
 		673CF40D2063AB7C00C329F6 /* GeneralDataLoadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CF40A2063AB7C00C329F6 /* GeneralDataLoadingViewModel.swift */; };
@@ -385,6 +393,10 @@
 		67A1FF941EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A1FF931EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift */; };
 		67A1FF951EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A1FF931EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift */; };
 		67A1FF971EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A1FF931EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift */; };
+		67C7B1792068BB1C00C9EDA3 /* NumberFormattingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C7B1782068BB1C00C9EDA3 /* NumberFormattingService.swift */; };
+		67C7B17A2068BB1C00C9EDA3 /* NumberFormattingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C7B1782068BB1C00C9EDA3 /* NumberFormattingService.swift */; };
+		67C7B17B2068BB1C00C9EDA3 /* NumberFormattingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C7B1782068BB1C00C9EDA3 /* NumberFormattingService.swift */; };
+		67C7B17C2068BB1C00C9EDA3 /* NumberFormattingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C7B1782068BB1C00C9EDA3 /* NumberFormattingService.swift */; };
 		67CAF8AC2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8AB2065189C00527085 /* NetworkService+ActivityIndicator.swift */; };
 		67CAF8AD2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8AB2065189C00527085 /* NetworkService+ActivityIndicator.swift */; };
 		67CAF8AE2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CAF8AB2065189C00527085 /* NetworkService+ActivityIndicator.swift */; };
@@ -615,6 +627,8 @@
 		67186B301EB248F100CFAFFB /* LeadKit iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "LeadKit iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		67186B411EB24AA000CFAFFB /* iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = iOS.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		67186C1A1EB24B7800CFAFFB /* Info-iOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-iOS.plist"; sourceTree = "<group>"; };
+		673564F02068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormattingService+DefaultImplementation.swift"; sourceTree = "<group>"; };
+		673564F52068C68D00F0CBED /* NumberFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormat.swift; sourceTree = "<group>"; };
 		673CF40A2063AB7C00C329F6 /* GeneralDataLoadingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralDataLoadingViewModel.swift; sourceTree = "<group>"; };
 		673CF4102063ABD100C329F6 /* GeneralDataLoadingState+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GeneralDataLoadingState+Extensions.swift"; sourceTree = "<group>"; };
 		673CF4172063D50700C329F6 /* GeneralDataLoadingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralDataLoadingController.swift; sourceTree = "<group>"; };
@@ -656,6 +670,7 @@
 		679C77D61F98F7A60094BE10 /* UIAlertController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extensions.swift"; sourceTree = "<group>"; };
 		67A1FF8E1EBCA09B00D6C89F /* UIImage+Spinner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Spinner.swift"; sourceTree = "<group>"; };
 		67A1FF931EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CABasicAnimation+Rotation.swift"; sourceTree = "<group>"; };
+		67C7B1782068BB1C00C9EDA3 /* NumberFormattingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormattingService.swift; sourceTree = "<group>"; };
 		67CAF8AB2065189C00527085 /* NetworkService+ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkService+ActivityIndicator.swift"; sourceTree = "<group>"; };
 		67CAF8B020651E1E00527085 /* ConfigurableNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableNetworkService.swift; sourceTree = "<group>"; };
 		67CAF8B520651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConfigurableNetworkService+DefaultImplementation.swift"; sourceTree = "<group>"; };
@@ -853,6 +868,7 @@
 		671461DA1EB3396E00EAB194 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				673564EF2068C29100F0CBED /* NumberFormattingService */,
 				671461DB1EB3396E00EAB194 /* Alamofire */,
 				EFBE57CE1EC35ED90040E00A /* Array */,
 				67A1FF921EBCA64A00D6C89F /* CABasicAnimation */,
@@ -1058,6 +1074,7 @@
 		671462221EB3396E00EAB194 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
+				67C7B1772068BADA00C9EDA3 /* NumberFormattingService */,
 				67EB7FC5206148C400BDD9FB /* DataLoading */,
 				67CAF8AF20651E0F00527085 /* NetworkService */,
 				673CF4202063D8EB00C329F6 /* Rx */,
@@ -1193,6 +1210,14 @@
 				671463B41EB34B1E00EAB194 /* PaginationViewModelTests.swift */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		673564EF2068C29100F0CBED /* NumberFormattingService */ = {
+			isa = PBXGroup;
+			children = (
+				673564F02068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift */,
+			);
+			path = NumberFormattingService;
 			sourceTree = "<group>";
 		};
 		673CF4152063AC0000C329F6 /* GeneralDataLoading */ = {
@@ -1361,6 +1386,15 @@
 				67A1FF931EBCA65E00D6C89F /* CABasicAnimation+Rotation.swift */,
 			);
 			path = CABasicAnimation;
+			sourceTree = "<group>";
+		};
+		67C7B1772068BADA00C9EDA3 /* NumberFormattingService */ = {
+			isa = PBXGroup;
+			children = (
+				673564F52068C68D00F0CBED /* NumberFormat.swift */,
+				67C7B1782068BB1C00C9EDA3 /* NumberFormattingService.swift */,
+			);
+			path = NumberFormattingService;
 			sourceTree = "<group>";
 		};
 		67CAF8AF20651E0F00527085 /* NetworkService */ = {
@@ -2352,6 +2386,7 @@
 				674AF55C1EC45B1600038A8F /* UIActivityIndicatorView+LoadingIndicator.swift in Sources */,
 				671463401EB3396E00EAB194 /* ModuleConfigurator.swift in Sources */,
 				67A1FF8F1EBCA09B00D6C89F /* UIImage+Spinner.swift in Sources */,
+				673564F62068C68D00F0CBED /* NumberFormat.swift in Sources */,
 				671462901EB3396E00EAB194 /* CGImage+Crop.swift in Sources */,
 				671462FC1EB3396E00EAB194 /* UIView+XibNameProtocol.swift in Sources */,
 				67EB7FC0206140E600BDD9FB /* TotalCountCursor.swift in Sources */,
@@ -2395,6 +2430,7 @@
 				40F118491F8FF223004AADAF /* TableRow+AppearanceExtension.swift in Sources */,
 				671463701EB3396E00EAB194 /* ApiRequestParameters.swift in Sources */,
 				A658E5501F8CD9350093527A /* Array+SeparatorRowBoxExtensions.swift in Sources */,
+				673564F12068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift in Sources */,
 				671462EC1EB3396E00EAB194 /* UIImage+Extensions.swift in Sources */,
 				677452AE206274630024EEEF /* PaginationWrapper.swift in Sources */,
 				A6E0DDF11F8A6C80002CA74E /* SeparatorConfiguration.swift in Sources */,
@@ -2523,6 +2559,7 @@
 				A6F32C0B1F6EBE5C00AC08EE /* String+LocalizedComponent.swift in Sources */,
 				6714627E1EB3396E00EAB194 /* AlamofireManager+Extensions.swift in Sources */,
 				677452AB206263360024EEEF /* CursorType+RxDataSourceDefaultImplementation.swift in Sources */,
+				673564F32068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift in Sources */,
 				6771DFDA1EE99EBA002DCDAE /* DateFormattingService.swift in Sources */,
 				67EB7FD620615D1700BDD9FB /* ResettableCursorType.swift in Sources */,
 				6714625A1EB3396E00EAB194 /* Log.swift in Sources */,
@@ -2534,6 +2571,7 @@
 				67CAF8AD2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */,
 				A676AE481F97D28A001F9214 /* String+Extensions.swift in Sources */,
 				673CF4242063D90600C329F6 /* DisposeBagHolder.swift in Sources */,
+				67C7B17B2068BB1C00C9EDA3 /* NumberFormattingService.swift in Sources */,
 				671462A21EB3396E00EAB194 /* Double+Rounding.swift in Sources */,
 				67EB7FF32061682F00BDD9FB /* TotalCountCursorListingResult+DefaultTotalCountCursorListingResult.swift in Sources */,
 				6714625E1EB3396E00EAB194 /* LogFormatter.swift in Sources */,
@@ -2550,6 +2588,7 @@
 				6774527620624E820024EEEF /* DataLoadingModel.swift in Sources */,
 				6771DFE61EE9A00A002DCDAE /* DateFormattingArguments+DateFormatter.swift in Sources */,
 				6714624A1EB3396E00EAB194 /* FixedPageCursor.swift in Sources */,
+				673564F82068C68D00F0CBED /* NumberFormat.swift in Sources */,
 				671462CA1EB3396E00EAB194 /* String+Localization.swift in Sources */,
 				677452A620625FA90024EEEF /* RxDataSource.swift in Sources */,
 				671462BA1EB3396E00EAB194 /* Sequence+ConcurrentMap.swift in Sources */,
@@ -2613,6 +2652,7 @@
 				6774527C206252020024EEEF /* DataLoadingState.swift in Sources */,
 				677452AC206263360024EEEF /* CursorType+RxDataSourceDefaultImplementation.swift in Sources */,
 				6714632B1EB3396E00EAB194 /* BaseViewModel.swift in Sources */,
+				673564F42068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift in Sources */,
 				677452A220625EEE0024EEEF /* PaginationDataLoadingModel.swift in Sources */,
 				673CF4362063E29B00C329F6 /* TextWithButtonPlaceholder.swift in Sources */,
 				A6F32C0C1F6EBE5C00AC08EE /* String+LocalizedComponent.swift in Sources */,
@@ -2628,6 +2668,7 @@
 				6774526E206249E30024EEEF /* UICollectionView+PaginationWrappable.swift in Sources */,
 				6771DFED1EEA7CB8002DCDAE /* DateFormattingService+MappingTransform.swift in Sources */,
 				671463A91EB340C000EAB194 /* UIViewController+ConfigurableController.swift in Sources */,
+				673564F92068C68D00F0CBED /* NumberFormat.swift in Sources */,
 				A676AE581F981131001F9214 /* ObservableMappable.swift in Sources */,
 				671463731EB3396E00EAB194 /* ApiRequestParameters.swift in Sources */,
 				671462EF1EB3396E00EAB194 /* UIImage+Extensions.swift in Sources */,
@@ -2683,6 +2724,7 @@
 				6714638F1EB3396E00EAB194 /* SolidFillDrawingOperation.swift in Sources */,
 				67CAF8B920651E4F00527085 /* ConfigurableNetworkService+DefaultImplementation.swift in Sources */,
 				67E6C2381EBB32F5007842A6 /* SingleLoadCursor.swift in Sources */,
+				67C7B17C2068BB1C00C9EDA3 /* NumberFormattingService.swift in Sources */,
 				671462531EB3396E00EAB194 /* StaticCursor.swift in Sources */,
 				6714629F1EB3396E00EAB194 /* CursorType+Slice.swift in Sources */,
 				6714636B1EB3396E00EAB194 /* ConfigurableView.swift in Sources */,
@@ -2730,9 +2772,11 @@
 				671463111EB3396E00EAB194 /* UIViewController+DefaultXibName.swift in Sources */,
 				671463411EB3396E00EAB194 /* ModuleConfigurator.swift in Sources */,
 				671462911EB3396E00EAB194 /* CGImage+Crop.swift in Sources */,
+				673564F72068C68D00F0CBED /* NumberFormat.swift in Sources */,
 				67051ADC1EBC7C36008EADC0 /* SpinnerView.swift in Sources */,
 				671462FD1EB3396E00EAB194 /* UIView+XibNameProtocol.swift in Sources */,
 				671463851EB3396E00EAB194 /* ResizeDrawingOperation.swift in Sources */,
+				673564F22068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift in Sources */,
 				671462D11EB3396E00EAB194 /* UIScrollView+Support.swift in Sources */,
 				6774528E20625C9E0024EEEF /* GeneralDataLoadingState.swift in Sources */,
 				671463911EB3396E00EAB194 /* TemplateDrawingOperation.swift in Sources */,
@@ -2794,6 +2838,7 @@
 				673CF40C2063AB7C00C329F6 /* GeneralDataLoadingViewModel.swift in Sources */,
 				671462B91EB3396E00EAB194 /* Sequence+ConcurrentMap.swift in Sources */,
 				671463751EB3396E00EAB194 /* BorderDrawingOperation.swift in Sources */,
+				67C7B17A2068BB1C00C9EDA3 /* NumberFormattingService.swift in Sources */,
 				673CF4122063ABD100C329F6 /* GeneralDataLoadingState+Extensions.swift in Sources */,
 				6714633D1EB3396E00EAB194 /* LoadingIndicator.swift in Sources */,
 				671463191EB3396E00EAB194 /* UIWindow+Extensions.swift in Sources */,

--- a/LeadKit.xcodeproj/project.pbxproj
+++ b/LeadKit.xcodeproj/project.pbxproj
@@ -308,7 +308,6 @@
 		673CF4392063E7CE00C329F6 /* GeneralDataLoadingController+DefaultImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CF4372063E7CE00C329F6 /* GeneralDataLoadingController+DefaultImplementation.swift */; };
 		673CF43A2063E7CE00C329F6 /* GeneralDataLoadingController+DefaultImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CF4372063E7CE00C329F6 /* GeneralDataLoadingController+DefaultImplementation.swift */; };
 		673CF43B2063E80B00C329F6 /* GeneralDataLoadingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CF4172063D50700C329F6 /* GeneralDataLoadingController.swift */; };
-		673CF43C2063E80B00C329F6 /* GeneralDataLoadingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673CF4172063D50700C329F6 /* GeneralDataLoadingController.swift */; };
 		674AF55C1EC45B1600038A8F /* UIActivityIndicatorView+LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674AF55B1EC45B1600038A8F /* UIActivityIndicatorView+LoadingIndicator.swift */; };
 		674AF55D1EC45B1600038A8F /* UIActivityIndicatorView+LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674AF55B1EC45B1600038A8F /* UIActivityIndicatorView+LoadingIndicator.swift */; };
 		674AF55E1EC45B1600038A8F /* UIActivityIndicatorView+LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674AF55B1EC45B1600038A8F /* UIActivityIndicatorView+LoadingIndicator.swift */; };
@@ -2582,7 +2581,6 @@
 				671462721EB3396E00EAB194 /* CursorError.swift in Sources */,
 				671462961EB3396E00EAB194 /* CGSize+CGContextSize.swift in Sources */,
 				671463661EB3396E00EAB194 /* ViewHeightProtocol.swift in Sources */,
-				673CF43C2063E80B00C329F6 /* GeneralDataLoadingController.swift in Sources */,
 				67EB7FD120615B8900BDD9FB /* TotalCountCursorConfiguration.swift in Sources */,
 				673CF40D2063AB7C00C329F6 /* GeneralDataLoadingViewModel.swift in Sources */,
 				67EB7FC9206148D000BDD9FB /* TotalCountCursorListingResult.swift in Sources */,

--- a/Sources/Extensions/Array/Array+Extensions.swift
+++ b/Sources/Extensions/Array/Array+Extensions.swift
@@ -70,7 +70,7 @@ public extension Array {
 
     // Subscript for safe access to element by index
     subscript(safe index: Index) -> Element? {
-        return indices.contains(index) ? self[index] : nil
+        return (index < count && index >= 0) ? self[index] : nil
     }
 
 }

--- a/Sources/Extensions/Array/Array+Extensions.swift
+++ b/Sources/Extensions/Array/Array+Extensions.swift
@@ -70,7 +70,7 @@ public extension Array {
 
     // Subscript for safe access to element by index
     subscript(safe index: Index) -> Element? {
-        return index < count ? self[index] : nil
+        return indices.contains(index) ? self[index] : nil
     }
 
 }

--- a/Sources/Extensions/NetworkService/ConfigurableNetworkService+DefaultImplementation.swift
+++ b/Sources/Extensions/NetworkService/ConfigurableNetworkService+DefaultImplementation.swift
@@ -20,13 +20,31 @@
 //  THE SOFTWARE.
 //
 
-import RxSwift
+import Alamofire
 
-public extension NetworkService {
+public extension ConfigurableNetworkService {
 
-    /// Let netwrok service automatically show / hide activity indicator
-    func bindActivityIndicator() -> Disposable? {
-        return nil
+    static var timeoutInterval: TimeInterval {
+        return 20
+    }
+
+    static var serverTrustPolicies: [String: ServerTrustPolicy] {
+        return [
+            baseUrl: .disableEvaluation
+        ]
+    }
+
+    static var sessionConfiguration: URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = timeoutInterval
+        configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
+
+        return configuration
+    }
+
+    static var sessionManager: SessionManager {
+        return SessionManager(configuration: sessionConfiguration,
+                              serverTrustPolicyManager: ServerTrustPolicyManager(policies: serverTrustPolicies))
     }
 
 }

--- a/Sources/Extensions/NetworkService/NetworkService+ActivityIndicator-UIApplication.swift
+++ b/Sources/Extensions/NetworkService/NetworkService+ActivityIndicator-UIApplication.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2018 Touch Instinct
+//  Copyright (c) 2017 Touch Instinct
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the Software), to deal
@@ -26,7 +26,9 @@ public extension NetworkService {
 
     /// Let netwrok service automatically show / hide activity indicator
     func bindActivityIndicator() -> Disposable? {
-        return nil
+        return requestCount
+            .map { $0 != 0 }
+            .drive(UIApplication.shared.rx.isNetworkActivityIndicatorVisible)
     }
 
 }

--- a/Sources/Extensions/NumberFormattingService/NumberFormattingService+DefaultImplementation.swift
+++ b/Sources/Extensions/NumberFormattingService/NumberFormattingService+DefaultImplementation.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright (c) 2018 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public extension NumberFormattingService {
+
+    /// Computed static property. Use only once for `formatters` field implementation!
+    static var computedFormatters: [NumberFormatType: NumberFormatter] {
+        return Dictionary(uniqueKeysWithValues: NumberFormatType.allValues.map { ($0, $0.numberFormatter) })
+    }
+
+    static func numberFormatter(for format: NumberFormatType) -> NumberFormatter {
+        guard let formatter = formatters[format] else {
+            fatalError("Unregistered number formatter for \(format)")
+        }
+
+        return formatter
+    }
+
+    static func string(from number: NSNumber, format: NumberFormatType, defaultString: String = "") -> String {
+        return numberFormatter(for: format).string(from: number) ?? defaultString
+    }
+
+    static func string(from number: Decimal, format: NumberFormatType, defaultString: String = "") -> String {
+        return string(from: NSDecimalNumber(decimal: number), format: format, defaultString: defaultString)
+    }
+
+    static func string(from number: Int, format: NumberFormatType, defaultString: String = "") -> String {
+        return string(from: NSNumber(value: number), format: format, defaultString: defaultString)
+    }
+
+    static func string(from number: Int64, format: NumberFormatType, defaultString: String = "") -> String {
+        return string(from: NSNumber(value: number), format: format, defaultString: defaultString)
+    }
+
+    static func string(from number: Float, format: NumberFormatType, defaultString: String = "") -> String {
+        return string(from: NSNumber(value: Double(number)), format: format, defaultString: defaultString)
+    }
+
+    static func string(from number: Double, format: NumberFormatType, defaultString: String = "") -> String {
+        return string(from: NSNumber(value: number), format: format, defaultString: defaultString)
+    }
+
+}

--- a/Sources/Extensions/NumberFormattingService/NumberFormattingService+DefaultImplementation.swift
+++ b/Sources/Extensions/NumberFormattingService/NumberFormattingService+DefaultImplementation.swift
@@ -26,7 +26,7 @@ public extension NumberFormattingService {
 
     /// Computed static property. Use only once for `formatters` field implementation!
     static var computedFormatters: [NumberFormatType: NumberFormatter] {
-        return Dictionary(uniqueKeysWithValues: NumberFormatType.allValues.map { ($0, $0.numberFormatter) })
+        return Dictionary(uniqueKeysWithValues: NumberFormatType.allOptions.map { ($0, $0.numberFormatter) })
     }
 
     static func numberFormatter(for format: NumberFormatType) -> NumberFormatter {

--- a/Sources/Protocols/NetworkService/ConfigurableNetworkService.swift
+++ b/Sources/Protocols/NetworkService/ConfigurableNetworkService.swift
@@ -20,13 +20,24 @@
 //  THE SOFTWARE.
 //
 
-import RxSwift
+import Alamofire
 
-public extension NetworkService {
+/// Protocol with some basic settings for network service configuration.
+public protocol ConfigurableNetworkService {
 
-    /// Let netwrok service automatically show / hide activity indicator
-    func bindActivityIndicator() -> Disposable? {
-        return nil
-    }
+    /// Base api url string.
+    static var baseUrl: String { get }
+
+    /// Timeout interval for requests.
+    static var timeoutInterval: TimeInterval { get }
+
+    /// Server trust policies.
+    static var serverTrustPolicies: [String: ServerTrustPolicy] { get }
+
+    /// Session configuration to use in SessionManager.
+    static var sessionConfiguration: URLSessionConfiguration { get }
+
+    /// Session manager.
+    static var sessionManager: SessionManager { get }
 
 }

--- a/Sources/Protocols/NumberFormattingService/NumberFormat.swift
+++ b/Sources/Protocols/NumberFormattingService/NumberFormat.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright (c) 2018 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// Protocol for describing number format.
+public protocol NumberFormat: Hashable {
+
+    /// All available options
+    static var allValues: [Self] { get }
+
+    /// A NumberFormatter instance for this format.
+    var numberFormatter: NumberFormatter { get }
+
+}

--- a/Sources/Protocols/NumberFormattingService/NumberFormat.swift
+++ b/Sources/Protocols/NumberFormattingService/NumberFormat.swift
@@ -25,8 +25,8 @@ import Foundation
 /// Protocol for describing number format.
 public protocol NumberFormat: Hashable {
 
-    /// All available options
-    static var allValues: [Self] { get }
+    /// All available options.
+    static var allOptions: [Self] { get }
 
     /// A NumberFormatter instance for this format.
     var numberFormatter: NumberFormatter { get }

--- a/Sources/Protocols/NumberFormattingService/NumberFormattingService.swift
+++ b/Sources/Protocols/NumberFormattingService/NumberFormattingService.swift
@@ -1,0 +1,92 @@
+//
+//  Copyright (c) 2018 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// Protocol that contains number formatting functions for often used number types.
+public protocol NumberFormattingService {
+
+    associatedtype NumberFormatType: NumberFormat
+
+    static var formatters: [NumberFormatType: NumberFormatter] { get }
+
+    /// Method returns NumberFormatter for given NumberFormatType.
+    ///
+    /// - Parameter format: A number format under which should be configured NumberFormatter.
+    /// - Returns: Configured NumberFormatter instance.
+    static func numberFormatter(for format: NumberFormatType) -> NumberFormatter
+
+    /// Method format number in given format. If formatting fails - it returns default string.
+    ///
+    /// - Parameters:
+    ///   - number: A number to format.
+    ///   - format: A format that should be used for number formatting.
+    ///   - defaultString: Default string if formatting will fail.
+    /// - Returns: An string that contains formatted number or default string if formatting did fail.
+    static func string(from number: NSNumber, format: NumberFormatType, defaultString: String) -> String
+
+    /// Method format number in given format. If formatting fails - it returns default string.
+    ///
+    /// - Parameters:
+    ///   - number: A number to format.
+    ///   - format: A format that should be used for number formatting.
+    ///   - defaultString: Default string if formatting will fail.
+    /// - Returns: An string that contains formatted number or default string if formatting did fail.
+    static func string(from number: Int, format: NumberFormatType, defaultString: String) -> String
+
+    /// Method format number in given format. If formatting fails - it returns default string.
+    ///
+    /// - Parameters:
+    ///   - number: A number to format.
+    ///   - format: A format that should be used for number formatting.
+    ///   - defaultString: Default string if formatting will fail.
+    /// - Returns: An string that contains formatted number or default string if formatting did fail.
+    static func string(from number: Int64, format: NumberFormatType, defaultString: String) -> String
+
+    /// Method format number in given format. If formatting fails - it returns default string.
+    ///
+    /// - Parameters:
+    ///   - number: A number to format.
+    ///   - format: A format that should be used for number formatting.
+    ///   - defaultString: Default string if formatting will fail.
+    /// - Returns: An string that contains formatted number or default string if formatting did fail.
+    static func string(from number: Float, format: NumberFormatType, defaultString: String) -> String
+
+    /// Method format number in given format. If formatting fails - it returns default string.
+    ///
+    /// - Parameters:
+    ///   - number: A number to format.
+    ///   - format: A format that should be used for number formatting.
+    ///   - defaultString: Default string if formatting will fail.
+    /// - Returns: An string that contains formatted number or default string if formatting did fail.
+    static func string(from number: Double, format: NumberFormatType, defaultString: String) -> String
+
+    /// Method format number in given format. If formatting fails - it returns default string.
+    ///
+    /// - Parameters:
+    ///   - number: A number to format.
+    ///   - format: A format that should be used for number formatting.
+    ///   - defaultString: Default string if formatting will fail.
+    /// - Returns: An string that contains formatted number or default string if formatting did fail.
+    static func string(from number: Decimal, format: NumberFormatType, defaultString: String) -> String
+
+}


### PR DESCRIPTION
1] Часть кода `DefaultNetworkService` из LeadKitAddtions перешла в LeadKit. Теперь не нужно подключать LeadKitAddtions со всеми зависимостями ради DefaultNetworkService'а.

Выглядеть будет вот так:
```swift
class JetNetworkService: NetworkService, ConfigurableNetworkService {

    static let baseUrl = "https://my-super.url"

}
```

2] Теперь есть базовая реализация для NumberFormatter'ов для всех проектов.

Выглядеть будет вот так:
```swift
enum JetNumberFormatType: NumberFormat {

    static let allOptions: [JetNumberFormatType] = [.plainDecimal,
                                                   .integer,
                                                   .integerPercent]

    /// `100.0` or `200.2`
    case plainDecimal

    /// `100` or `2`
    case integer

    /// `100%` or `-2%`
    case integerPercent

    var numberFormatter: NumberFormatter {
        let formatter = NumberFormatter()

        switch self {
        case .plainDecimal:
            formatter.numberStyle = .decimal
            formatter.minimumFractionDigits = 1
            formatter.maximumFractionDigits = 1
        case .integer:
            formatter.minimumFractionDigits = 0
            formatter.maximumFractionDigits = 0
        case .integerPercent:
            formatter.numberStyle = .percent
            formatter.minimumFractionDigits = 0
            formatter.maximumFractionDigits = 2
            formatter.multiplier = NSNumber(value: 1)
        }

        return formatter
    }

}

final class JetNumberFormatter: NumberFormattingService {

    typealias NumberFormatType = JetNumberFormatType

    static let formatters = computedFormatters

}

JetNumberFormatter.string(from: 0.94, format: .integerPercent)
JetNumberFormatter.string(from: 1.94, format: .plainDecimal)
JetNumberFormatter.string(from: 1.94, format: .integer)
```