### PR TITLE
Fix doubling separator line issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+### 0.7.7
+- **Fix**: Fix doubling separator line issue
 
 ### 0.7.6
 

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "0.7.6"
+  s.version         = "0.7.7"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/Sources/Extensions/Array/Array+SeparatorRowBoxExtensions.swift
+++ b/Sources/Extensions/Array/Array+SeparatorRowBoxExtensions.swift
@@ -43,8 +43,8 @@ public extension Array where Element == SeparatorRowBox {
         case 1:
             first?.set(separatorType: .full(extremeSeparatorConfiguration, extremeSeparatorConfiguration))
         default:
-            forEach { $0.set(separatorType: .full(middleSeparatorConfiguration, middleSeparatorConfiguration)) }
-            first?.set(separatorType: .top(extremeSeparatorConfiguration))
+            forEach { $0.set(separatorType: .bottom(middleSeparatorConfiguration))}
+            first?.set(separatorType: .full(extremeSeparatorConfiguration, middleSeparatorConfiguration))
             last?.set(separatorType: .bottom(extremeSeparatorConfiguration))
         }
     }


### PR DESCRIPTION
The problem is that for 2..last-1 rows performs .full(middleSeparatorConfiguration, middleSeparatorConfiguration) action, that leads to doubling separator line height