### PR TITLE
UniversalMappable added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.7.12
+- **Add**: `UniversalMappable` protocol to have ability generate generic mapping models
+
 ### 0.7.11
 - **Fix**: `addHeaderBackground` cells overlapping.
 

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "0.7.11"
+  s.version         = "0.7.12"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/LeadKit.xcodeproj/project.pbxproj
+++ b/LeadKit.xcodeproj/project.pbxproj
@@ -544,6 +544,22 @@
 		EF24213B2076D5C700FA9BE6 /* NetworkServiceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2421392076D5BD00FA9BE6 /* NetworkServiceConfiguration.swift */; };
 		EF24213C2076D5C900FA9BE6 /* NetworkServiceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2421392076D5BD00FA9BE6 /* NetworkServiceConfiguration.swift */; };
 		EF24213D2076D5CA00FA9BE6 /* NetworkServiceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2421392076D5BD00FA9BE6 /* NetworkServiceConfiguration.swift */; };
+		EFA4C66420864F9C008C4DD8 /* UniversalMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C66320864F9C008C4DD8 /* UniversalMappable.swift */; };
+		EFA4C66520864F9C008C4DD8 /* UniversalMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C66320864F9C008C4DD8 /* UniversalMappable.swift */; };
+		EFA4C66620864F9C008C4DD8 /* UniversalMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C66320864F9C008C4DD8 /* UniversalMappable.swift */; };
+		EFA4C66720864F9C008C4DD8 /* UniversalMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C66320864F9C008C4DD8 /* UniversalMappable.swift */; };
+		EFA4C66A208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C669208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift */; };
+		EFA4C66B208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C669208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift */; };
+		EFA4C66C208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C669208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift */; };
+		EFA4C66D208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C669208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift */; };
+		EFA4C66F20865126008C4DD8 /* UniversalMappable+SwiftStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C66E20865126008C4DD8 /* UniversalMappable+SwiftStandard.swift */; };
+		EFA4C67020865126008C4DD8 /* UniversalMappable+SwiftStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C66E20865126008C4DD8 /* UniversalMappable+SwiftStandard.swift */; };
+		EFA4C67120865126008C4DD8 /* UniversalMappable+SwiftStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C66E20865126008C4DD8 /* UniversalMappable+SwiftStandard.swift */; };
+		EFA4C67220865126008C4DD8 /* UniversalMappable+SwiftStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C66E20865126008C4DD8 /* UniversalMappable+SwiftStandard.swift */; };
+		EFA4C6742086514A008C4DD8 /* UniversalMappable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C6732086514A008C4DD8 /* UniversalMappable+Extensions.swift */; };
+		EFA4C6752086514A008C4DD8 /* UniversalMappable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C6732086514A008C4DD8 /* UniversalMappable+Extensions.swift */; };
+		EFA4C6762086514A008C4DD8 /* UniversalMappable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C6732086514A008C4DD8 /* UniversalMappable+Extensions.swift */; };
+		EFA4C6772086514A008C4DD8 /* UniversalMappable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4C6732086514A008C4DD8 /* UniversalMappable+Extensions.swift */; };
 		EFBE57D01EC35EF20040E00A /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBE57CF1EC35EF20040E00A /* Array+Extensions.swift */; };
 		EFBE57D11EC35EF20040E00A /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBE57CF1EC35EF20040E00A /* Array+Extensions.swift */; };
 		EFBE57D21EC35EF20040E00A /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBE57CF1EC35EF20040E00A /* Array+Extensions.swift */; };
@@ -776,6 +792,10 @@
 		D840E55867DC9BB63460B856 /* Pods-LeadKit tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeadKit tvOSTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-LeadKit tvOSTests/Pods-LeadKit tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		DF1148A279C7AC7A42B0A0F8 /* Pods_LeadKit_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LeadKit_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF2421392076D5BD00FA9BE6 /* NetworkServiceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkServiceConfiguration.swift; sourceTree = "<group>"; };
+		EFA4C66320864F9C008C4DD8 /* UniversalMappable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalMappable.swift; sourceTree = "<group>"; };
+		EFA4C669208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UniversalMappable+ImmutableMappable.swift"; sourceTree = "<group>"; };
+		EFA4C66E20865126008C4DD8 /* UniversalMappable+SwiftStandard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UniversalMappable+SwiftStandard.swift"; sourceTree = "<group>"; };
+		EFA4C6732086514A008C4DD8 /* UniversalMappable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UniversalMappable+Extensions.swift"; sourceTree = "<group>"; };
 		EFBE57CF1EC35EF20040E00A /* Array+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		EFBE57DA1EC361620040E00A /* UIView+Layout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Layout.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -919,7 +939,6 @@
 		671461DA1EB3396E00EAB194 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				67153E3E207DFB980049D8C0 /* FloatingPoint */,
 				671461DB1EB3396E00EAB194 /* Alamofire */,
 				EFBE57CE1EC35ED90040E00A /* Array */,
 				67A1FF921EBCA64A00D6C89F /* CABasicAnimation */,
@@ -929,6 +948,7 @@
 				6771DFE81EEA7C8F002DCDAE /* DateFormattingService */,
 				671461EA1EB3396E00EAB194 /* Double */,
 				672947E2206EA59E00AC6B6B /* Drawing */,
+				67153E3E207DFB980049D8C0 /* FloatingPoint */,
 				6714639C1EB33AC200EAB194 /* NetworkService */,
 				676B22A0206A6249002E9F8A /* NSAttributedString */,
 				673564EF2068C29100F0CBED /* NumberFormattingService */,
@@ -941,6 +961,7 @@
 				671462021EB3396E00EAB194 /* TimeInterval */,
 				671462081EB3396E00EAB194 /* UIColor */,
 				672947E0206EA36B00AC6B6B /* UIKit */,
+				EFA4C6682086508B008C4DD8 /* UniversalMappable */,
 				6727476C206CCD3100725163 /* Views */,
 			);
 			path = Extensions;
@@ -1119,27 +1140,28 @@
 		671462221EB3396E00EAB194 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
-				67EB7FC5206148C400BDD9FB /* DataLoading */,
-				67274783206CD7E500725163 /* DateFormatingService */,
-				672947E3206EA63200AC6B6B /* Drawing */,
-				67C7B1772068BADA00C9EDA3 /* NumberFormattingService */,
-				673CF4202063D8EB00C329F6 /* Rx */,
-				678D269C20692BFF00B05B93 /* Views */,
 				679C77D41F98F78E0094BE10 /* AlertRepresentable.swift */,
 				671463A11EB33FF600EAB194 /* Animatable.swift */,
 				40F118461F8FEF97004AADAF /* AppearanceConfigurable.swift */,
 				671462231EB3396E00EAB194 /* BaseViewModel.swift */,
 				671462241EB3396E00EAB194 /* ConfigurableController.swift */,
 				671462331EB3396E00EAB194 /* ConfigurableView.swift */,
+				67EB7FC5206148C400BDD9FB /* DataLoading */,
+				67274783206CD7E500725163 /* DateFormatingService */,
+				672947E3206EA63200AC6B6B /* Drawing */,
 				671462281EB3396E00EAB194 /* LoadingIndicator.swift */,
 				671462291EB3396E00EAB194 /* ModuleConfigurator.swift */,
+				67C7B1772068BADA00C9EDA3 /* NumberFormattingService */,
 				A676AE541F981121001F9214 /* ObservableMappable.swift */,
 				6714622B1EB3396E00EAB194 /* ResettableType.swift */,
 				6714622C1EB3396E00EAB194 /* ReuseIdentifierProtocol.swift */,
+				673CF4202063D8EB00C329F6 /* Rx */,
 				67955D51206D216B0021ECD2 /* Singleton.swift */,
 				6714622E1EB3396E00EAB194 /* StaticViewHeightProtocol.swift */,
 				671462311EB3396E00EAB194 /* SupportProtocol.swift */,
+				EFA4C66320864F9C008C4DD8 /* UniversalMappable.swift */,
 				671462321EB3396E00EAB194 /* ViewHeightProtocol.swift */,
+				678D269C20692BFF00B05B93 /* Views */,
 				671462341EB3396E00EAB194 /* XibNameProtocol.swift */,
 			);
 			path = Protocols;
@@ -1764,6 +1786,16 @@
 				EF2421392076D5BD00FA9BE6 /* NetworkServiceConfiguration.swift */,
 			);
 			path = NetworkService;
+			sourceTree = "<group>";
+		};
+		EFA4C6682086508B008C4DD8 /* UniversalMappable */ = {
+			isa = PBXGroup;
+			children = (
+				EFA4C6732086514A008C4DD8 /* UniversalMappable+Extensions.swift */,
+				EFA4C669208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift */,
+				EFA4C66E20865126008C4DD8 /* UniversalMappable+SwiftStandard.swift */,
+			);
+			path = UniversalMappable;
 			sourceTree = "<group>";
 		};
 		EFBE57CE1EC35ED90040E00A /* Array */ = {
@@ -2561,6 +2593,7 @@
 				671463401EB3396E00EAB194 /* ModuleConfigurator.swift in Sources */,
 				67A1FF8F1EBCA09B00D6C89F /* UIImage+Spinner.swift in Sources */,
 				673564F62068C68D00F0CBED /* NumberFormat.swift in Sources */,
+				EFA4C66420864F9C008C4DD8 /* UniversalMappable.swift in Sources */,
 				671462901EB3396E00EAB194 /* CGImage+Crop.swift in Sources */,
 				671462FC1EB3396E00EAB194 /* UIView+XibNameProtocol.swift in Sources */,
 				67EB7FC0206140E600BDD9FB /* TotalCountCursor.swift in Sources */,
@@ -2579,6 +2612,7 @@
 				67FDC25F1FA310EA00C76A77 /* RequestError.swift in Sources */,
 				67745268206249360024EEEF /* UITableView+PaginationWrappable.swift in Sources */,
 				6714624C1EB3396E00EAB194 /* MapCursor.swift in Sources */,
+				EFA4C66F20865126008C4DD8 /* UniversalMappable+SwiftStandard.swift in Sources */,
 				A6C9A4FA1F8BBCF2009311CC /* EmptyCell.swift in Sources */,
 				6737CFA3207220960063E056 /* SeparatorConfiguration+Extensions.swift in Sources */,
 				671463241EB3396E00EAB194 /* Any+TypeName.swift in Sources */,
@@ -2588,6 +2622,7 @@
 				671463281EB3396E00EAB194 /* BaseViewModel.swift in Sources */,
 				671AD25C206A343300EAF887 /* VoidBlock.swift in Sources */,
 				A6E0DDDF1F8A696F002CA74E /* SeparatorCell.swift in Sources */,
+				EFA4C6742086514A008C4DD8 /* UniversalMappable+Extensions.swift in Sources */,
 				67153E40207DFBA80049D8C0 /* FloatingPoint+DegreesRadiansConvertion.swift in Sources */,
 				671462AC1EB3396E00EAB194 /* Observable+DeferredJust.swift in Sources */,
 				671463001EB3396E00EAB194 /* UIView+LoadFromNib.swift in Sources */,
@@ -2602,6 +2637,7 @@
 				671463041EB3396E00EAB194 /* UIView+LoadingIndicator.swift in Sources */,
 				6774527420624E820024EEEF /* DataLoadingModel.swift in Sources */,
 				40F118491F8FF223004AADAF /* TableRow+AppearanceExtension.swift in Sources */,
+				EFA4C66A208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift in Sources */,
 				6727476E206CCDDB00725163 /* ViewBackground+Configuration.swift in Sources */,
 				671463701EB3396E00EAB194 /* ApiRequestParameters.swift in Sources */,
 				676B22A2206A626D002E9F8A /* NSAttributedString+Extensions.swift in Sources */,
@@ -2706,6 +2742,7 @@
 				67EB7FE620615DE000BDD9FB /* DataSource.swift in Sources */,
 				6714634A1EB3396E00EAB194 /* ResettableType.swift in Sources */,
 				671462E61EB3396E00EAB194 /* UIColor+Hex.swift in Sources */,
+				EFA4C6762086514A008C4DD8 /* UniversalMappable+Extensions.swift in Sources */,
 				A676AE4D1F9810C1001F9214 /* Any+Cast.swift in Sources */,
 				67FD4384206BD24B005B0C64 /* EqutableOptionalArray.swift in Sources */,
 				EFBE57D21EC35EF20040E00A /* Array+Extensions.swift in Sources */,
@@ -2744,8 +2781,10 @@
 				6714632A1EB3396E00EAB194 /* BaseViewModel.swift in Sources */,
 				671462AE1EB3396E00EAB194 /* Observable+DeferredJust.swift in Sources */,
 				67EB7FDC20615D5B00BDD9FB /* ResettableRxCursorDataSource.swift in Sources */,
+				EFA4C66620864F9C008C4DD8 /* UniversalMappable.swift in Sources */,
 				A6F32C0B1F6EBE5C00AC08EE /* String+LocalizedComponent.swift in Sources */,
 				6714627E1EB3396E00EAB194 /* AlamofireManager+Extensions.swift in Sources */,
+				EFA4C66C208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift in Sources */,
 				677452AB206263360024EEEF /* CursorType+RxDataSourceDefaultImplementation.swift in Sources */,
 				673564F32068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift in Sources */,
 				67EB7FD620615D1700BDD9FB /* ResettableCursorType.swift in Sources */,
@@ -2792,6 +2831,7 @@
 				671462DA1EB3396E00EAB194 /* TimeInterval+DateComponents.swift in Sources */,
 				6714638E1EB3396E00EAB194 /* SolidFillDrawingOperation.swift in Sources */,
 				6774529420625D170024EEEF /* GeneralDataLoadingModel.swift in Sources */,
+				EFA4C67120865126008C4DD8 /* UniversalMappable+SwiftStandard.swift in Sources */,
 				67FDC2611FA310EA00C76A77 /* RequestError.swift in Sources */,
 				671AD25E206A343300EAF887 /* VoidBlock.swift in Sources */,
 				671462521EB3396E00EAB194 /* StaticCursor.swift in Sources */,
@@ -2846,6 +2886,7 @@
 				67FD4385206BD24B005B0C64 /* EqutableOptionalArray.swift in Sources */,
 				67CAF8AE2065189C00527085 /* NetworkService+ActivityIndicator.swift in Sources */,
 				6714638B1EB3396E00EAB194 /* RoundDrawingOperation.swift in Sources */,
+				EFA4C66D208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift in Sources */,
 				67EB7FFF206176C900BDD9FB /* AnyPaginationWrappable.swift in Sources */,
 				A676AE4A1F97D28A001F9214 /* String+Extensions.swift in Sources */,
 				671463831EB3396E00EAB194 /* PaddingDrawingOperation.swift in Sources */,
@@ -2853,6 +2894,7 @@
 				677452AC206263360024EEEF /* CursorType+RxDataSourceDefaultImplementation.swift in Sources */,
 				6714632B1EB3396E00EAB194 /* BaseViewModel.swift in Sources */,
 				673564F42068C2AD00F0CBED /* NumberFormattingService+DefaultImplementation.swift in Sources */,
+				EFA4C67220865126008C4DD8 /* UniversalMappable+SwiftStandard.swift in Sources */,
 				677452A220625EEE0024EEEF /* PaginationDataLoadingModel.swift in Sources */,
 				673CF4362063E29B00C329F6 /* TextWithButtonPlaceholder.swift in Sources */,
 				A6F32C0C1F6EBE5C00AC08EE /* String+LocalizedComponent.swift in Sources */,
@@ -2883,6 +2925,7 @@
 				671462A31EB3396E00EAB194 /* Double+Rounding.swift in Sources */,
 				6714630B1EB3396E00EAB194 /* UIView+Rotation.swift in Sources */,
 				673CF4192063D50700C329F6 /* GeneralDataLoadingController.swift in Sources */,
+				EFA4C66720864F9C008C4DD8 /* UniversalMappable.swift in Sources */,
 				6792623E206EB0EC00308E62 /* CellSeparatorType+Extensions.swift in Sources */,
 				6714626F1EB3396E00EAB194 /* XibView.swift in Sources */,
 				6714637F1EB3396E00EAB194 /* ImageDrawingOperation.swift in Sources */,
@@ -2896,6 +2939,7 @@
 				67EB7FDD20615D5B00BDD9FB /* ResettableRxCursorDataSource.swift in Sources */,
 				677452A720625FA90024EEEF /* RxDataSource.swift in Sources */,
 				6774527720624E820024EEEF /* DataLoadingModel.swift in Sources */,
+				EFA4C6772086514A008C4DD8 /* UniversalMappable+Extensions.swift in Sources */,
 				67926239206EB0AE00308E62 /* CellSeparatorType.swift in Sources */,
 				678D267C20691D8200B05B93 /* DataModelFieldBinding.swift in Sources */,
 				6714639B1EB3396E00EAB194 /* AnyLoadingIndicator.swift in Sources */,
@@ -2982,6 +3026,7 @@
 				671462691EB3396E00EAB194 /* NetworkService.swift in Sources */,
 				671463111EB3396E00EAB194 /* UIViewController+DefaultXibName.swift in Sources */,
 				671463411EB3396E00EAB194 /* ModuleConfigurator.swift in Sources */,
+				EFA4C67020865126008C4DD8 /* UniversalMappable+SwiftStandard.swift in Sources */,
 				67153E41207DFBA80049D8C0 /* FloatingPoint+DegreesRadiansConvertion.swift in Sources */,
 				671462911EB3396E00EAB194 /* CGImage+Crop.swift in Sources */,
 				673564F72068C68D00F0CBED /* NumberFormat.swift in Sources */,
@@ -3059,8 +3104,11 @@
 				673CF4122063ABD100C329F6 /* GeneralDataLoadingState+Extensions.swift in Sources */,
 				6714633D1EB3396E00EAB194 /* LoadingIndicator.swift in Sources */,
 				671463191EB3396E00EAB194 /* UIWindow+Extensions.swift in Sources */,
+				EFA4C6752086514A008C4DD8 /* UniversalMappable+Extensions.swift in Sources */,
 				6727478B206CD83600725163 /* DateFormat.swift in Sources */,
 				EFBE57DC1EC361620040E00A /* UIView+Layout.swift in Sources */,
+				EFA4C66B208650B4008C4DD8 /* UniversalMappable+ImmutableMappable.swift in Sources */,
+				EFA4C66520864F9C008C4DD8 /* UniversalMappable.swift in Sources */,
 				67A1FF901EBCA09B00D6C89F /* UIImage+Spinner.swift in Sources */,
 				6774529B20625E5B0024EEEF /* PaginationDataLoadingState.swift in Sources */,
 				671463791EB3396E00EAB194 /* CALayerDrawingOperation.swift in Sources */,

--- a/Sources/Extensions/UniversalMappable/UniversalMappable+Extensions.swift
+++ b/Sources/Extensions/UniversalMappable/UniversalMappable+Extensions.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright (c) 2018 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import ObjectMapper
+
+public extension UniversalMappable {
+
+    func encode(to map: Map, key: String) {
+        self >>> map[key]
+    }
+
+}

--- a/Sources/Extensions/UniversalMappable/UniversalMappable+ImmutableMappable.swift
+++ b/Sources/Extensions/UniversalMappable/UniversalMappable+ImmutableMappable.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright (c) 2018 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import ObjectMapper
+
+public extension UniversalMappable where Self: ImmutableMappable {
+
+    func encode(to map: Map, key: String) {
+        self >>> map[key]
+    }
+
+    static func decode(from map: Map, key: String) throws -> ImmutableMappable {
+        let result: ImmutableMappable = try map.value(key)
+        return result
+    }
+
+}

--- a/Sources/Extensions/UniversalMappable/UniversalMappable+ImmutableMappable.swift
+++ b/Sources/Extensions/UniversalMappable/UniversalMappable+ImmutableMappable.swift
@@ -29,8 +29,7 @@ public extension UniversalMappable where Self: ImmutableMappable {
     }
 
     static func decode(from map: Map, key: String) throws -> ImmutableMappable {
-        let result: ImmutableMappable = try map.value(key)
-        return result
+        return try map.value(key)
     }
 
 }

--- a/Sources/Extensions/UniversalMappable/UniversalMappable+SwiftStandard.swift
+++ b/Sources/Extensions/UniversalMappable/UniversalMappable+SwiftStandard.swift
@@ -1,0 +1,75 @@
+//
+//  Copyright (c) 2018 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import ObjectMapper
+
+extension Int: UniversalMappable {}
+extension Int8: UniversalMappable {}
+extension Int16: UniversalMappable {}
+extension Int32: UniversalMappable {}
+extension Int64: UniversalMappable {}
+
+extension UInt: UniversalMappable {}
+extension UInt8: UniversalMappable {}
+extension UInt16: UniversalMappable {}
+extension UInt32: UniversalMappable {}
+extension UInt64: UniversalMappable {}
+
+extension Float: UniversalMappable {}       // aka float32
+extension Float64: UniversalMappable {}     // aka double
+extension Float80: UniversalMappable {}     // aka extended
+
+public extension BinaryInteger where Self: UniversalMappable {
+
+    static func decode(from map: Map, key: String) throws -> Self {
+        let result: Self = try map.value(key)
+        return result
+    }
+
+}
+
+public extension BinaryFloatingPoint where Self: UniversalMappable {
+
+    static func decode(from map: Map, key: String) throws -> Self {
+        let result: Self = try map.value(key)
+        return result
+    }
+
+}
+
+extension Bool: UniversalMappable {
+
+    public static func decode(from map: Map, key: String) throws -> Bool {
+        let result: Bool = try map.value(key)
+        return result
+    }
+
+}
+
+extension String: UniversalMappable {
+
+    public static func decode(from map: Map, key: String) throws -> String {
+        let result: String = try map.value(key)
+        return result
+    }
+
+}

--- a/Sources/Extensions/UniversalMappable/UniversalMappable+SwiftStandard.swift
+++ b/Sources/Extensions/UniversalMappable/UniversalMappable+SwiftStandard.swift
@@ -36,7 +36,6 @@ extension UInt64: UniversalMappable {}
 
 extension Float: UniversalMappable {}       // aka float32
 extension Float64: UniversalMappable {}     // aka double
-extension Float80: UniversalMappable {}     // aka extended
 
 public extension BinaryInteger where Self: UniversalMappable {
 

--- a/Sources/Extensions/UniversalMappable/UniversalMappable+SwiftStandard.swift
+++ b/Sources/Extensions/UniversalMappable/UniversalMappable+SwiftStandard.swift
@@ -41,8 +41,7 @@ extension Float80: UniversalMappable {}     // aka extended
 public extension BinaryInteger where Self: UniversalMappable {
 
     static func decode(from map: Map, key: String) throws -> Self {
-        let result: Self = try map.value(key)
-        return result
+        return try map.value(key)
     }
 
 }
@@ -50,8 +49,7 @@ public extension BinaryInteger where Self: UniversalMappable {
 public extension BinaryFloatingPoint where Self: UniversalMappable {
 
     static func decode(from map: Map, key: String) throws -> Self {
-        let result: Self = try map.value(key)
-        return result
+        return try map.value(key)
     }
 
 }
@@ -59,8 +57,7 @@ public extension BinaryFloatingPoint where Self: UniversalMappable {
 extension Bool: UniversalMappable {
 
     public static func decode(from map: Map, key: String) throws -> Bool {
-        let result: Bool = try map.value(key)
-        return result
+        return try map.value(key)
     }
 
 }
@@ -68,8 +65,7 @@ extension Bool: UniversalMappable {
 extension String: UniversalMappable {
 
     public static func decode(from map: Map, key: String) throws -> String {
-        let result: String = try map.value(key)
-        return result
+        return try map.value(key)
     }
 
 }

--- a/Sources/Protocols/UniversalMappable.swift
+++ b/Sources/Protocols/UniversalMappable.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright (c) 2018 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import ObjectMapper
+
+/// Protocol for map uniformly generated models
+public protocol UniversalMappable {
+
+    /// Method to serialize object into JSON
+    func encode(to map: Map, key: String)
+
+    /// Method to deserialize object from JSON
+    static func decode(from map: Map, key: String) throws -> Self
+
+}


### PR DESCRIPTION
`UniversalMappable` protocol added to have ability generate generic mapping models

```swift
class BaseResponse<T: UniversalMappable>: ImmutableMappable {

    let result: T
    let error: Float

    required init(map: Map) throws {
        result = try T.decode(from: map, key: "result")
        error = try map.value("error")
    }

    func mapping(map: Map) {
        result.encode(to: map, key: "result")
        error >>> map["error"]
    }
}
```