### PR TITLE
Feature/tifoundationutils codable key value storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 0.9.44
+- **Add**: `TIFoundationUtils` - set of helpers for Foundation framework classes.
+
+#### TISwiftUtils
+- **Add**: `BackingStore` - a property wrapper that wraps storage and defines getter and setter for accessing value from it.
+
+#### TIFoundationUtils
+- **Add**: `CodableKeyValueStorage` - storage that can get and set codable objects by the key.
+
+
 ### 0.9.43
 - **Fix**: `OTPSwiftView`'s dependencies.
 

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "0.9.43"
+  s.version         = "0.9.44"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
     .library(name: "TITransitions", targets: ["TITransitions"]),
     .library(name: "TIUIKitCore", targets: ["TIUIKitCore"]),
     .library(name: "TISwiftUtils", targets: ["TISwiftUtils"]),
+    .library(name: "TIFoundationUtils", targets: ["TIFoundationUtils"]),
     .library(name: "TIUIElements", targets: ["TIUIElements"]),
     .library(name: "OTPSwiftView", targets: ["OTPSwiftView"])
   ],
@@ -17,6 +18,7 @@ let package = Package(
     .target(name: "TITransitions", path: "TITransitions/Sources"),
     .target(name: "TIUIKitCore", path: "TIUIKitCore/Sources"),
     .target(name: "TISwiftUtils", path: "TISwiftUtils/Sources"),
+    .target(name: "TIFoundationUtils", dependencies: ["TISwiftUtils"], path: "TIFoundationUtils/Sources"),
     .target(name: "TIUIElements", dependencies: ["TIUIKitCore"], path: "TIUIElements/Sources"),
     .target(name: "OTPSwiftView", dependencies: ["TIUIKitCore", "TISwiftUtils"], path: "OTPSwiftView/Sources")
   ]

--- a/TIFoundationUtils/README.md
+++ b/TIFoundationUtils/README.md
@@ -1,0 +1,62 @@
+# TIFoundationUtils
+
+Set of helpers for Foundation framework classes.
+
+* [CodableKeyValueStorage](#codablekeyvaluestorage)
+
+## CodableKeyValueStorage
+
+Storage that can get and set codable objects by the key.
+
+Implementations: `UserDefaults`
+
+### Example
+
+```swift
+struct ProfileInfo: Codable {
+    let userName: String
+}
+```
+
+Keys:
+
+```swift
+extension StorageKey {
+    static var profileKey: StorageKey<ProfileInfo> {
+        .init(rawValue: "profileKey")
+    }
+
+    static var onboardingFinishedKey: StorageKey<Bool> {
+        .init(rawValue: "onboardingFinishedKey")
+    }
+}
+```
+
+#### Subscript example
+
+```swift
+var defaults = UserDefaults.standard
+defaults[.profileKey] = ProfileInfo(userName: "John Appleseed")
+defaults[.profileKey] = "Agent Smith" // this will threat compile error:
+// Cannot assign value of type 'String' to subscript of type 'ProfileInfo'
+```
+#### @propertyWrapper example
+
+```swift
+final class ViewModel {
+    @UserDefaultsCodableBackingStore(key: .profileKey, codableKeyValueStorage: .standard)
+    var profile: ProfileInfo?
+
+    // This will threat compile error:
+    // Cannot convert value of type 'BackingStore<UserDefaults, Bool?>' to specified type 'ProfileInfo?'
+    @UserDefaultsCodableBackingStore(key: .onboardingFinishedKey, codableKeyValueStorage: .standard)
+    var wrongKeyProfile: ProfileInfo?
+
+    // For primitive types we can't use default json decoder/encoder
+    @UserDefaultsCodableBackingStore(key: .onboardingFinishedKey,
+                                     codableKeyValueStorage: .standard,
+                                     decoder: UnarchiverKeyValueDecoder(),
+                                     encoder: ArchiverKeyValueEncoder())
+    var onboardingFinished = false
+}
+```

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/CodableKeyValueStorage+BackingStore.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/CodableKeyValueStorage+BackingStore.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import TISwiftUtils
+
+public typealias CodableKeyValueBackingStore<S: CodableKeyValueStorage, T: Codable> = BackingStore<S, T>
+
+public extension BackingStore where Store: CodableKeyValueStorage, StoreContent: Codable {
+    init<Value: Codable>(key: StorageKey<Value>,
+                         codableKeyValueStorage: Store,
+                         decoder: CodableKeyValueDecoder = JSONKeyValueDecoder(),
+                         encoder: CodableKeyValueEncoder = JSONKeyValueEncoder())
+        where StoreContent == Value? {
+
+        self.init(store: codableKeyValueStorage,
+                  getClosure: { try? $0.codableObject(forKey: key, decoder: decoder) },
+                  setClosure: { try? $0.setOrRemove(codableObject: $1, forKey: key, encoder: encoder) })
+    }
+
+    init(wrappedValue: StoreContent,
+         key: StorageKey<StoreContent>,
+         codableKeyValueStorage: Store,
+         decoder: CodableKeyValueDecoder = JSONKeyValueDecoder(),
+         encoder: CodableKeyValueEncoder = JSONKeyValueEncoder()) {
+
+        self.init(store: codableKeyValueStorage,
+                  getClosure: { $0.codableObject(forKey: key, defaultValue: wrappedValue, decoder: decoder) },
+                  setClosure: { try? $0.setOrRemove(codableObject: $1, forKey: key, encoder: encoder) })
+    }
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/CodableKeyValueStorage.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/CodableKeyValueStorage.swift
@@ -1,0 +1,91 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public protocol CodableKeyValueStorage {
+    /// Returns the object with specified type associated with the first occurrence of the specified key.
+    /// - Parameters:
+    ///   - key: A key in the storage.
+    ///   - decoder: CodableKeyValueDecoder to decode stored data.
+    /// - Returns: The object with specified type associated with the specified key,
+    /// or throw exception if the key was not found.
+    /// - Throws: CodableStorageError
+    func codableObject<Value: Decodable>(forKey key: StorageKey<Value>,
+                                         decoder: CodableKeyValueDecoder) throws -> Value
+
+    /// Set or remove the value of the specified key in the storage.
+    /// - Parameters:
+    ///   - object: The object with specified type to store.
+    ///   - key: The key with which to associate with the value.
+    ///   - encoder: CodableKeyValueEncoder to encode to encode passed object.
+    /// - Throws: EncodingError if error is occured during passed object encoding.
+    func set<Value: Encodable>(encodableObject: Value,
+                               forKey key: StorageKey<Value>,
+                               encoder: CodableKeyValueEncoder) throws
+
+    /// Removes value for specific key
+    /// - Parameter key: The key with which to associate with the value.
+    /// - Throws: EncodingError if error is occured during reading/writing.
+    func removeCodableValue<Value: Codable>(forKey key: StorageKey<Value>) throws
+}
+
+public extension CodableKeyValueStorage {
+
+    /// Returns the object with specified type associated with the first occurrence of the specified key.
+    /// - Parameters:
+    ///   - key: A key in the storage.
+    ///   - defaultValue: A default value that will be used if there is no such value for specified key,
+    ///   - decoder: CodableKeyValueDecoder to decode stored data.
+    /// or if error occurred during decoding
+    /// - Returns: The object with specified type associated with the specified key, or passed default value
+    /// if there is no such value for specified key or if error occurred during mapping.
+    func codableObject<Value: Decodable>(forKey key: StorageKey<Value>,
+                                         defaultValue: Value,
+                                         decoder: CodableKeyValueDecoder = JSONKeyValueDecoder()) -> Value {
+
+        (try? codableObject(forKey: key, decoder: decoder)) ?? defaultValue
+    }
+
+    func setOrRemove<Value: Codable>(codableObject: Value?,
+                                     forKey key: StorageKey<Value>,
+                                     encoder: CodableKeyValueEncoder = JSONKeyValueEncoder()) throws {
+
+        if let codableObject = codableObject {
+            try set(encodableObject: codableObject, forKey: key, encoder: encoder)
+        } else {
+            try? removeCodableValue(forKey: key)
+        }
+    }
+
+    subscript<Value: Codable>(key: StorageKey<Value>,
+                              decoder: CodableKeyValueDecoder = JSONKeyValueDecoder(),
+                              encoder: CodableKeyValueEncoder = JSONKeyValueEncoder()) -> Value? {
+
+        get {
+            try? codableObject(forKey: key, decoder: decoder)
+        }
+        set {
+            try? setOrRemove(codableObject: newValue, forKey: key, encoder: encoder)
+        }
+    }
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/Decoders/CodableKeyValueDecoder.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/Decoders/CodableKeyValueDecoder.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public protocol CodableKeyValueDecoder {
+    func decodeDecodable<Value: Decodable>(from data: Data, for key: StorageKey<Value>) throws -> Value
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/Decoders/JSONKeyValueDecoder.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/Decoders/JSONKeyValueDecoder.swift
@@ -1,0 +1,39 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+open class JSONKeyValueDecoder: CodableKeyValueDecoder {
+    private let jsonDecoder: JSONDecoder
+
+    public init(jsonDecoder: JSONDecoder = JSONDecoder()) {
+        self.jsonDecoder = jsonDecoder
+    }
+
+    open func decodeDecodable<Value: Decodable>(from data: Data, for key: StorageKey<Value>) throws -> Value {
+        do {
+            return try jsonDecoder.decode(Value.self, from: data)
+        } catch {
+            throw StorageError.unableToDecode(underlyingError: error)
+        }
+    }
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/Decoders/UnarchiverKeyValueDecoder.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/Decoders/UnarchiverKeyValueDecoder.swift
@@ -1,0 +1,47 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+open class UnarchiverKeyValueDecoder: CodableKeyValueDecoder {
+    public init() {}
+
+    open func decodeDecodable<Value: Decodable>(from data: Data, for key: StorageKey<Value>) throws -> Value {
+        let unarchiver: NSKeyedUnarchiver
+
+        do {
+            unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+        } catch {
+            throw StorageError.unableToDecode(underlyingError: error)
+        }
+
+        defer {
+            unarchiver.finishDecoding()
+        }
+
+        guard let decodableObject = unarchiver.decodeDecodable(Value.self, forKey: key.rawValue) else {
+            throw StorageError.valueNotFound
+        }
+
+        return decodableObject
+    }
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/Encoders/ArchiverKeyValueEncoder.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/Encoders/ArchiverKeyValueEncoder.swift
@@ -1,0 +1,41 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+open class ArchiverKeyValueEncoder: CodableKeyValueEncoder {
+    public init() {}
+
+    open func encodeEncodable<Value: Encodable>(value: Value, for key: StorageKey<Value>) throws -> Data {
+        let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+
+        do {
+            try archiver.encodeEncodable(value, forKey: key.rawValue)
+        } catch {
+            throw StorageError.unableToEncode(underlyingError: error)
+        }
+
+        archiver.finishEncoding()
+
+        return archiver.encodedData
+    }
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/Encoders/CodableKeyValueEncoder.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/Encoders/CodableKeyValueEncoder.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public protocol CodableKeyValueEncoder {
+    func encodeEncodable<Value: Encodable>(value: Value, for key: StorageKey<Value>) throws -> Data
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/Encoders/JSONKeyValueEncoder.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/Encoders/JSONKeyValueEncoder.swift
@@ -1,0 +1,39 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+open class JSONKeyValueEncoder: CodableKeyValueEncoder {
+    private let jsonEncoder: JSONEncoder
+
+    public init(jsonEncoder: JSONEncoder = JSONEncoder()) {
+        self.jsonEncoder = jsonEncoder
+    }
+
+    open func encodeEncodable<Value: Encodable>(value: Value, for key: StorageKey<Value>) throws -> Data {
+        do {
+            return try jsonEncoder.encode(value)
+        } catch {
+            throw StorageError.unableToEncode(underlyingError: error)
+        }
+    }
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/StorageError.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/StorageError.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+enum StorageError: Error {
+    case valueNotFound
+    case unableToExtractData(underlyingError: Error)
+    case unableToDecode(underlyingError: Error)
+    case unableToEncode(underlyingError: Error)
+    case unableToWriteData(underlyingError: Error)
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/StorageKey.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/StorageKey.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+public struct StorageKey<ValueType>: RawRepresentable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/UserDefaults+CodableKeyValueStorage.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/UserDefaults+CodableKeyValueStorage.swift
@@ -1,0 +1,52 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension UserDefaults: CodableKeyValueStorage {
+    public func codableObject<Value: Decodable>(forKey key: StorageKey<Value>,
+                                                decoder: CodableKeyValueDecoder) throws -> Value {
+
+        guard let storedData = data(forKey: key.rawValue) else {
+            throw StorageError.valueNotFound
+        }
+
+        return try decoder.decodeDecodable(from: storedData, for: key)
+    }
+
+    public func set<Value: Encodable>(encodableObject: Value,
+                                      forKey key: StorageKey<Value>,
+                                      encoder: CodableKeyValueEncoder) throws {
+
+        let encodedData = try encoder.encodeEncodable(value: encodableObject, for: key)
+
+        set(encodedData, forKey: key.rawValue)
+    }
+
+    public func removeCodableValue<Value: Codable>(forKey key: StorageKey<Value>) throws {
+        guard data(forKey: key.rawValue) != nil else {
+            throw StorageError.valueNotFound
+        }
+
+        removeObject(forKey: key.rawValue)
+    }
+}

--- a/TIFoundationUtils/Sources/CodableKeyValueStorage/UserDefaultsCodableBackingStore.swift
+++ b/TIFoundationUtils/Sources/CodableKeyValueStorage/UserDefaultsCodableBackingStore.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public typealias UserDefaultsCodableBackingStore<T: Codable> = CodableKeyValueBackingStore<UserDefaults, T>

--- a/TISwiftUtils/README.md
+++ b/TISwiftUtils/README.md
@@ -2,6 +2,23 @@
 
 Bunch of useful helpers for development.
 
+* [BackingStore](#backingstore)
+
+## BackingStore
+
+A property wrapper that wraps storage and defines getter and setter for accessing value from it.
+
+### Example
+
+```swift
+final class ViewModel {
+    @BackingStore(store: UserDefaults.standard,
+                  getClosure: { $0.bool(forKey: "hasFinishedOnboarding") },
+                  setClosure: { $0.set($1, forKey: "hasFinishedOnboarding") })
+    var hasFinishedOnboarding: Bool
+}
+```
+
 # Installation via SPM
 
 You can install this framework as a target of LeadKit.

--- a/TISwiftUtils/Sources/PropertyWrappers/BackingStore.swift
+++ b/TISwiftUtils/Sources/PropertyWrappers/BackingStore.swift
@@ -1,0 +1,65 @@
+//
+//  Copyright (c) 2020 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+@propertyWrapper public struct BackingStore<Store, StoreContent> {
+
+    public typealias InitClosure = (StoreContent) -> Store
+    public typealias GetClosure = (Store) -> StoreContent
+    public typealias SetClosure = (Store, StoreContent) -> Void
+
+    private let getClosure: GetClosure
+    private let setClosure: SetClosure
+
+    private let store: Store
+
+    public init(wrappedValue: StoreContent,
+                storageInitClosure: InitClosure,
+                getClosure: @escaping GetClosure,
+                setClosure: @escaping SetClosure) {
+
+        self.store = storageInitClosure(wrappedValue)
+        self.getClosure = getClosure
+        self.setClosure = setClosure
+    }
+
+    public init(store: Store,
+                getClosure: @escaping GetClosure,
+                setClosure: @escaping SetClosure) {
+
+        self.store = store
+        self.getClosure = getClosure
+        self.setClosure = setClosure
+    }
+
+    public var wrappedValue: StoreContent {
+        get {
+            getClosure(store)
+        }
+        set {
+            setClosure(store, newValue)
+        }
+    }
+
+    public var projectedValue: Store {
+        store
+    }
+}


### PR DESCRIPTION
Finally, you can do this:

```swift
var defaults = UserDefaults.standard
defaults[.profileKey] = ProfileInfo(userName: "John Appleseed")
defaults[.profileKey] = "Agent Smith" // this will threat compile error:
// Cannot assign value of type 'String' to subscript of type 'ProfileInfo'
```

and this

```swift
final class ViewModel {
    @UserDefaultsCodableBackingStore(key: .profileKey, codableKeyValueStorage: .standard)
    var profile: ProfileInfo?

    // This will threat compile error:
    // Cannot convert value of type 'BackingStore<UserDefaults, Bool?>' to specified type 'ProfileInfo?'
    @UserDefaultsCodableBackingStore(key: .onboardingFinishedKey, codableKeyValueStorage: .standard)
    var wrongKeyProfile: ProfileInfo?

    // For primitive types we can't use default json decoder/encoder
    @UserDefaultsCodableBackingStore(key: .onboardingFinishedKey,
                                     codableKeyValueStorage: .standard,
                                     decoder: UnarchiverKeyValueDecoder(),
                                     encoder: ArchiverKeyValueEncoder())
    var onboardingFinished = false
}
```