### PR TITLE
Fix convert from decimal to double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.12.1
+- **Fix**: Convert from Decimal to Double.
+
 ### 0.12.0
 - **Add**: StatefulButton & RoundedStatefulButton to TIUIElements.
 - **Add**: added CACornerMask rounding extension to TIUIElements.

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "0.10.9"
+  s.version         = "0.12.1"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/Sources/Classes/Controllers/BaseOrientationController.swift
+++ b/Sources/Classes/Controllers/BaseOrientationController.swift
@@ -23,7 +23,7 @@ open class BaseOrientationController: UIViewController {
                 return super.supportedInterfaceOrientations
             }
         }
-    
+
     open override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         return forcedInterfaceOrientation ?? super.preferredInterfaceOrientationForPresentation
     }

--- a/Sources/Extensions/Decimal/Decimal+Values.swift
+++ b/Sources/Extensions/Decimal/Decimal+Values.swift
@@ -26,7 +26,14 @@ public extension Decimal {
 
     /// Conver Decimal to Double value
     var doubleValue: Double {
-        return NSDecimalNumber(decimal: self).doubleValue
+        var scannedValue = 0.0
+        let scanner = Scanner(string: description)
+
+        guard scanner.scanDouble(&scannedValue) else {
+            return NSDecimalNumber(decimal: self).doubleValue
+        }
+
+        return scannedValue
     }
 
     /// Conver Decimal to Int value

--- a/Sources/Extensions/Decimal/Decimal+Values.swift
+++ b/Sources/Extensions/Decimal/Decimal+Values.swift
@@ -26,14 +26,7 @@ public extension Decimal {
 
     /// Conver Decimal to Double value
     var doubleValue: Double {
-        var scannedValue = 0.0
-        let scanner = Scanner(string: description)
-
-        guard scanner.scanDouble(&scannedValue) else {
-            return NSDecimalNumber(decimal: self).doubleValue
-        }
-
-        return scannedValue
+        return NSString(string: description).doubleValue
     }
 
     /// Conver Decimal to Int value

--- a/Sources/Extensions/UIInterfaceOrientation/UIInterfaceOrientation+ VideoOrientation.swift
+++ b/Sources/Extensions/UIInterfaceOrientation/UIInterfaceOrientation+ VideoOrientation.swift
@@ -2,7 +2,7 @@ import Foundation
 import AVFoundation
 
 public extension UIInterfaceOrientation {
-    
+
     var videoOrientation: AVCaptureVideoOrientation {
             switch self {
             case .portrait, .unknown:
@@ -16,7 +16,7 @@ public extension UIInterfaceOrientation {
 
             case .portraitUpsideDown:
                 return .portraitUpsideDown
-                
+
             @unknown default:
                 return .portrait
             }


### PR DESCRIPTION
При получении double значения из NSDecimalNumber могут быть артефакты: 12.3200000001, что может быть критично при работе с hash функциями, округлениями и тд.
Получения значения double из строки дает более корректный результат. Можно было бы использовать Scanner, но там неудобно депрекейтится метод scanDouble для iOS 13 и можно подождать. Но в принципе разницы с NSString нет, Scanner просто учитывает пользовательские настройки, от которых в данном случае не толку. 