### PR TITLE
fix: DefaultRecoverableNetworkService `request` parameter was renamed to prevent ambiguous reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 1.12.1
+
+- **Update**: DefaultRecoverableNetworkService `request` parameter was renamed to prevent ambgious reference
 
 ### 1.12.0
 

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "1.12.0"
+  s.version         = "1.12.1"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/TIFoundationUtils/TIFoundationUtils.podspec
+++ b/TIFoundationUtils/TIFoundationUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIFoundationUtils'
-  s.version          = '1.12.0'
+  s.version          = '1.12.1'
   s.summary          = 'Set of helpers for Foundation framework classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIKeychainUtils/TIKeychainUtils.podspec
+++ b/TIKeychainUtils/TIKeychainUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIKeychainUtils'
-  s.version          = '1.12.0'
+  s.version          = '1.12.1'
   s.summary          = 'Set of helpers for Keychain classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMoyaNetworking/Sources/NetworkService/Cancellables/Cancellable+Conformances.swift
+++ b/TIMoyaNetworking/Sources/NetworkService/Cancellables/Cancellable+Conformances.swift
@@ -20,7 +20,11 @@
 //  THE SOFTWARE.
 //
 
-import Dispatch
 import Moya
+import Foundation
+
+@available(iOS 13.0, *)
+extension _Concurrency.Task: Cancellable {}
 
 extension DispatchWorkItem: Cancellable {}
+extension Operation: Cancellable {}

--- a/TIMoyaNetworking/TIMoyaNetworking.podspec
+++ b/TIMoyaNetworking/TIMoyaNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMoyaNetworking'
-  s.version          = '1.12.0'
+  s.version          = '1.12.1'
   s.summary          = 'Moya + Swagger network service.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworking/Sources/Request/EndpointRequest+Serialization.swift
+++ b/TINetworking/Sources/Request/EndpointRequest+Serialization.swift
@@ -32,13 +32,15 @@ public extension EndpointRequest {
         let (contentType, bodyData) = try serializer.serialize(body: body)
         let serializedQueryParameters = QueryStringParameterEncoding().encode(parameters: queryParameters)
 
-        var serializedHeaderParameters: [String: String]?
+        var serializedHeaderParameters: [String: String]
 
         if let customHeaderParameters = headerParameters {
             serializedHeaderParameters = HeaderParameterEncoding().encode(parameters: customHeaderParameters)
+        } else {
+            serializedHeaderParameters = [:]
         }
 
-        serializedHeaderParameters?[HTTPHeader.contentType(contentType).name] = contentType
+        serializedHeaderParameters[HTTPHeader.contentType(contentType).name] = contentType
 
         let cookies: [HTTPCookie]
 

--- a/TINetworking/TINetworking.podspec
+++ b/TINetworking/TINetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworking'
-  s.version          = '1.12.0'
+  s.version          = '1.12.1'
   s.summary          = 'Swagger-frendly networking layer helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TISwiftUtils/TISwiftUtils.podspec
+++ b/TISwiftUtils/TISwiftUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TISwiftUtils'
-  s.version          = '1.12.0'
+  s.version          = '1.12.1'
   s.summary          = 'Bunch of useful helpers for Swift development.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITableKitUtils/TITableKitUtils.podspec
+++ b/TITableKitUtils/TITableKitUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITableKitUtils'
-  s.version          = '1.12.0'
+  s.version          = '1.12.1'
   s.summary          = 'Set of helpers for TableKit classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITransitions/TITransitions.podspec
+++ b/TITransitions/TITransitions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITransitions'
-  s.version          = '1.12.0'
+  s.version          = '1.12.1'
   s.summary          = 'Set of custom transitions to present controller. '
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIElements/TIUIElements.podspec
+++ b/TIUIElements/TIUIElements.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIElements'
-  s.version          = '1.12.0'
+  s.version          = '1.12.1'
   s.summary          = 'Bunch of useful protocols and views.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIKitCore/TIUIKitCore.podspec
+++ b/TIUIKitCore/TIUIKitCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIKitCore'
-  s.version          = '1.12.0'
+  s.version          = '1.12.1'
   s.summary          = 'Core UI elements: protocols, views and helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
Небольшие переименования и багфикс