### PR TITLE
fix: gray table section background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 1.14.3
+
+- **Fix**: Creating headerView and footerView when initializing a section with rows in `TITableKitUtils`.
+- **Add**: Empty table section initialization method in `TITableKitUtils`.
+
 ### 1.14.2
 
 - **Update**: DateFormatters properties preset in reuse pools

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "1.14.2"
+  s.version         = "1.14.3"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/TIFoundationUtils/TIFoundationUtils.podspec
+++ b/TIFoundationUtils/TIFoundationUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIFoundationUtils'
-  s.version          = '1.14.2'
+  s.version          = '1.14.3'
   s.summary          = 'Set of helpers for Foundation framework classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIKeychainUtils/TIKeychainUtils.podspec
+++ b/TIKeychainUtils/TIKeychainUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIKeychainUtils'
-  s.version          = '1.14.2'
+  s.version          = '1.14.3'
   s.summary          = 'Set of helpers for Keychain classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMoyaNetworking/TIMoyaNetworking.podspec
+++ b/TIMoyaNetworking/TIMoyaNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMoyaNetworking'
-  s.version          = '1.14.2'
+  s.version          = '1.14.3'
   s.summary          = 'Moya + Swagger network service.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworking/TINetworking.podspec
+++ b/TINetworking/TINetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworking'
-  s.version          = '1.14.2'
+  s.version          = '1.14.3'
   s.summary          = 'Swagger-frendly networking layer helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TISwiftUtils/TISwiftUtils.podspec
+++ b/TISwiftUtils/TISwiftUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TISwiftUtils'
-  s.version          = '1.14.2'
+  s.version          = '1.14.3'
   s.summary          = 'Bunch of useful helpers for Swift development.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITableKitUtils/Sources/Extensions/TableSection/TableSection+Extensions.swift
+++ b/TITableKitUtils/Sources/Extensions/TableSection/TableSection+Extensions.swift
@@ -43,7 +43,7 @@ public extension TableSection {
     }
 
     /// Initializes an empty section.
-    static func nilSection() -> TableSection {
+    static func emptySection() -> TableSection {
         let tableSection = TableSection()
         
         if #available(iOS 15, *) {

--- a/TITableKitUtils/Sources/Extensions/TableSection/TableSection+Extensions.swift
+++ b/TITableKitUtils/Sources/Extensions/TableSection/TableSection+Extensions.swift
@@ -30,10 +30,30 @@ public extension TableSection {
     convenience init(onlyRows rows: [Row]) {
         self.init(rows: rows)
 
-        self.headerView = nil
-        self.footerView = nil
+        if #available(iOS 15, *) {
+            self.headerView = nil
+            self.footerView = nil
+        } else {
+            self.headerView = UIView()
+            self.footerView = UIView()
+        }
 
         self.headerHeight = .leastNonzeroMagnitude
         self.footerHeight = .leastNonzeroMagnitude
+    }
+
+    /// Initializes an empty section.
+    static func nilSection() -> TableSection {
+        let tableSection = TableSection()
+        
+        if #available(iOS 15, *) {
+            tableSection.headerView = nil
+            tableSection.footerView = nil
+        } else {
+            tableSection.headerView = UIView()
+            tableSection.footerView = UIView()
+        }
+        
+        return tableSection
     }
 }

--- a/TITableKitUtils/TITableKitUtils.podspec
+++ b/TITableKitUtils/TITableKitUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITableKitUtils'
-  s.version          = '1.14.2'
+  s.version          = '1.14.3'
   s.summary          = 'Set of helpers for TableKit classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITransitions/TITransitions.podspec
+++ b/TITransitions/TITransitions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITransitions'
-  s.version          = '1.14.2'
+  s.version          = '1.14.3'
   s.summary          = 'Set of custom transitions to present controller. '
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIElements/TIUIElements.podspec
+++ b/TIUIElements/TIUIElements.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIElements'
-  s.version          = '1.14.2'
+  s.version          = '1.14.3'
   s.summary          = 'Bunch of useful protocols and views.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIKitCore/TIUIKitCore.podspec
+++ b/TIUIKitCore/TIUIKitCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIKitCore'
-  s.version          = '1.14.2'
+  s.version          = '1.14.3'
   s.summary          = 'Core UI elements: protocols, views and helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
## На iOS <= 14 создавался background для UITableViewHeaderFooterView

- Пример с ликарда:

| Было | Стало |
| --- | --- |
| ![1](https://user-images.githubusercontent.com/87363997/162995883-d1bd6363-0538-4657-87c4-e6a6771211a1.png) | ![2](https://user-images.githubusercontent.com/87363997/162995895-d635c5a9-0c44-4458-b2d7-be577509ce3a.png) |