### PR TITLE
TINetworkingCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 1.15.0
+
+- **Update**: Network services in TIMoyaNetworking now passes MoyaError in result of EnpointRequest execution.
+- **Add**: `TINetworkingCache` module - caching results of EndpointRequests.
+- **Important Note**: `TINetworkingCache` may require you to add `DISABLE_DIAMOND_PROBLEM_DIAGNOSTIC=YES` flag to build settings of project target (see [probably related problem](https://forums.swift.org/t/adding-a-package-to-two-targets-in-one-projects-results-in-an-error/35007/18))
+
 ### 1.14.3
 
 - **Fix**: Creating headerView and footerView when initializing a section with rows in `TITableKitUtils`.

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "1.14.3"
+  s.version         = "1.15.0"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "Cache",
+        "repositoryURL": "https://github.com/hyperoslo/Cache.git",
+        "state": {
+          "branch": null,
+          "revision": "c7f4d633049c3bd649a353bad36f6c17e9df085f",
+          "version": "6.0.0"
+        }
+      },
+      {
         "package": "Cursors",
         "repositoryURL": "https://github.com/petropavel13/Cursors",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,12 @@ let package = Package(
     .library(name: "TIFoundationUtils", targets: ["TIFoundationUtils"]),
     .library(name: "TIKeychainUtils", targets: ["TIKeychainUtils"]),
     .library(name: "TITableKitUtils", targets: ["TITableKitUtils"]),
+
+    // MARK: - Networking
+
     .library(name: "TINetworking", targets: ["TINetworking"]),
     .library(name: "TIMoyaNetworking", targets: ["TIMoyaNetworking"]),
+    .library(name: "TINetworkingCache", targets: ["TINetworkingCache"]),
     
     // MARK: - Elements
     .library(name: "OTPSwiftView", targets: ["OTPSwiftView"]),
@@ -31,6 +35,7 @@ let package = Package(
     .package(url: "https://github.com/petropavel13/Cursors", .upToNextMajor(from: "0.5.1")),
     .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.4.0")),
     .package(url: "https://github.com/Moya/Moya.git", .upToNextMajor(from: "15.0.0")),
+    .package(url: "https://github.com/hyperoslo/Cache.git", .upToNextMajor(from: "6.0.0"))
   ],
   targets: [
     
@@ -48,6 +53,7 @@ let package = Package(
 
     .target(name: "TINetworking", dependencies: ["TISwiftUtils", "Alamofire"], path: "TINetworking/Sources"),
     .target(name: "TIMoyaNetworking", dependencies: ["TINetworking", "TIFoundationUtils", "Moya"], path: "TIMoyaNetworking"),
+    .target(name: "TINetworkingCache", dependencies: ["TIFoundationUtils", "TINetworking", "Cache"], path: "TINetworkingCache/Sources"),
     
     // MARK: - Elements
 

--- a/TIFoundationUtils/TIFoundationUtils.podspec
+++ b/TIFoundationUtils/TIFoundationUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIFoundationUtils'
-  s.version          = '1.14.3'
+  s.version          = '1.15.0'
   s.summary          = 'Set of helpers for Foundation framework classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIKeychainUtils/TIKeychainUtils.podspec
+++ b/TIKeychainUtils/TIKeychainUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIKeychainUtils'
-  s.version          = '1.14.3'
+  s.version          = '1.15.0'
   s.summary          = 'Set of helpers for Keychain classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMoyaNetworking/Sources/NetworkService/EndpointErrorResult.swift
+++ b/TIMoyaNetworking/Sources/NetworkService/EndpointErrorResult.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2020 Touch Instinct
+//  Copyright (c) 2022 Touch Instinct
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the Software), to deal
@@ -20,41 +20,24 @@
 //  THE SOFTWARE.
 //
 
-import TableKit
-import class UIKit.UIView
+import Moya
+import Foundation
 
-public extension TableSection {
+public enum EndpointErrorResult<E>: Error {
+    case apiError(E)
+    case networkError(MoyaError)
+}
 
-    /// Initializes section with rows and zero height footer and header.
-    ///
-    /// - Parameter rows: Rows to insert into section.
-    convenience init(onlyRows rows: [Row]) {
-        self.init(rows: rows)
+public extension EndpointErrorResult {
+    var isNetworkConnectionProblem: Bool {
+        guard case let .networkError(moyaError) = self,
+              case let .underlying(error, _) = moyaError,
+              case let .sessionTaskFailed(urlSessionTaskError) = error.asAFError,
+              let urlError = urlSessionTaskError as? URLError else {
 
-        if #available(iOS 15, *) {
-            self.headerView = nil
-            self.footerView = nil
-        } else {
-            self.headerView = UIView()
-            self.footerView = UIView()
-        }
+                  return false
+              }
 
-        self.headerHeight = .leastNonzeroMagnitude
-        self.footerHeight = .leastNonzeroMagnitude
-    }
-
-    /// Initializes an empty section.
-    static func emptySection() -> TableSection {
-        let tableSection = TableSection()
-        
-        if #available(iOS 15, *) {
-            tableSection.headerView = nil
-            tableSection.footerView = nil
-        } else {
-            tableSection.headerView = UIView()
-            tableSection.footerView = UIView()
-        }
-        
-        return tableSection
+        return urlError.code == .notConnectedToInternet
     }
 }

--- a/TIMoyaNetworking/Sources/NetworkService/EndpointRequestResult.swift
+++ b/TIMoyaNetworking/Sources/NetworkService/EndpointRequestResult.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2020 Touch Instinct
+//  Copyright (c) 2022 Touch Instinct
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the Software), to deal
@@ -20,41 +20,4 @@
 //  THE SOFTWARE.
 //
 
-import TableKit
-import class UIKit.UIView
-
-public extension TableSection {
-
-    /// Initializes section with rows and zero height footer and header.
-    ///
-    /// - Parameter rows: Rows to insert into section.
-    convenience init(onlyRows rows: [Row]) {
-        self.init(rows: rows)
-
-        if #available(iOS 15, *) {
-            self.headerView = nil
-            self.footerView = nil
-        } else {
-            self.headerView = UIView()
-            self.footerView = UIView()
-        }
-
-        self.headerHeight = .leastNonzeroMagnitude
-        self.footerHeight = .leastNonzeroMagnitude
-    }
-
-    /// Initializes an empty section.
-    static func emptySection() -> TableSection {
-        let tableSection = TableSection()
-        
-        if #available(iOS 15, *) {
-            tableSection.headerView = nil
-            tableSection.footerView = nil
-        } else {
-            tableSection.headerView = UIView()
-            tableSection.footerView = UIView()
-        }
-        
-        return tableSection
-    }
-}
+public typealias EndpointRequestResult<S: Decodable, F: Decodable> = Result<S, EndpointErrorResult<F>>

--- a/TIMoyaNetworking/TIMoyaNetworking.podspec
+++ b/TIMoyaNetworking/TIMoyaNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMoyaNetworking'
-  s.version          = '1.14.3'
+  s.version          = '1.15.0'
   s.summary          = 'Moya + Swagger network service.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworking/Sources/Request/SerializedRequest.swift
+++ b/TINetworking/Sources/Request/SerializedRequest.swift
@@ -52,3 +52,33 @@ public struct SerializedRequest {
         self.acceptableStatusCodes = acceptableStatusCodes
     }
 }
+
+extension SerializedRequest: Hashable {
+    private var comparableQueryParameters: [String: String] {
+        queryParameters.mapValues(String.init(describing:))
+    }
+    
+    public static func == (lhs: SerializedRequest, rhs: SerializedRequest) -> Bool {
+        lhs.baseURL == rhs.baseURL &&
+        lhs.path == rhs.path &&
+        lhs.method == rhs.method &&
+        lhs.bodyData == rhs.bodyData &&
+        lhs.comparableQueryParameters == rhs.comparableQueryParameters &&
+        lhs.headers == rhs.headers &&
+        lhs.cookies == rhs.cookies &&
+        lhs.acceptableStatusCodes == rhs.acceptableStatusCodes
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(baseURL)
+        hasher.combine(path)
+        hasher.combine(method)
+        hasher.combine(bodyData)
+        hasher.combine(comparableQueryParameters.keys.sorted())
+        hasher.combine(comparableQueryParameters.values.sorted())
+        hasher.combine(headers?.keys.sorted() ?? [])
+        hasher.combine(headers?.values.sorted() ?? [])
+        hasher.combine(cookies)
+        hasher.combine(acceptableStatusCodes.sorted())
+    }
+}

--- a/TINetworking/TINetworking.podspec
+++ b/TINetworking/TINetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworking'
-  s.version          = '1.14.3'
+  s.version          = '1.15.0'
   s.summary          = 'Swagger-frendly networking layer helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworkingCache/Sources/EndpointCacheService.swift
+++ b/TINetworkingCache/Sources/EndpointCacheService.swift
@@ -1,0 +1,81 @@
+//
+//  Copyright (c) 2022 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import TINetworking
+import TIFoundationUtils
+import Cache
+import Foundation
+
+public struct EndpointCacheService<Content: Codable> {
+    private let serializedRequest: SerializedRequest
+    private let multiLevelStorage: Storage<SerializedRequest, Content>
+
+    public var cachedContent: Content? {
+        get {
+            guard let entry = try? multiLevelStorage.entry(forKey: serializedRequest), !entry.expiry.isExpired else {
+                try? multiLevelStorage.removeObject(forKey: serializedRequest)
+                return nil
+            }
+
+            return entry.object
+        }
+        nonmutating set {
+            if let object = newValue {
+                try? multiLevelStorage.setObject(object,
+                                                 forKey: serializedRequest)
+            } else {
+                try? multiLevelStorage.removeObject(forKey: serializedRequest)
+            }
+        }
+    }
+
+    public init(serializedRequest: SerializedRequest,
+                cacheLifetime: TimeInterval,
+                jsonCodingConfigurator: JsonCodingConfigurator) throws {
+
+        self.serializedRequest = serializedRequest
+
+        let nameWithoutLeadingSlash: String
+
+        if serializedRequest.path.starts(with: "/") {
+            nameWithoutLeadingSlash = serializedRequest.path.drop { $0 == "/" }.string
+        } else {
+            nameWithoutLeadingSlash = serializedRequest.path
+        }
+
+        let diskConfig = DiskConfig(name: nameWithoutLeadingSlash,
+                                    expiry: .seconds(cacheLifetime))
+        let memoryConfig = MemoryConfig(expiry: .seconds(cacheLifetime),
+                                        countLimit: 0,
+                                        totalCostLimit: 0)
+
+        let transformer = Transformer {
+            try jsonCodingConfigurator.jsonEncoder.encode($0)
+        } fromData: {
+            try jsonCodingConfigurator.jsonDecoder.decode(Content.self, from: $0)
+        }
+
+        self.multiLevelStorage = try Storage(diskConfig: diskConfig,
+                                             memoryConfig: memoryConfig,
+                                             transformer: transformer)
+    }
+}

--- a/TINetworkingCache/TINetworkingCache.podspec
+++ b/TINetworkingCache/TINetworkingCache.podspec
@@ -1,14 +1,18 @@
 Pod::Spec.new do |s|
-  s.name             = 'TITransitions'
+  s.name             = 'TINetworkingCache'
   s.version          = '1.15.0'
-  s.summary          = 'Set of custom transitions to present controller. '
+  s.summary          = 'Caching results of EndpointRequests.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
-  s.author           = { 'Loupehope' => 'vladislav.suhomlinov@touchin.ru' }
+  s.author           = { 'petropavel13' => 'ivan.smolin@touchin.ru' }
   s.source           = { :git => 'https://github.com/TouchInstinct/LeadKit.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '11.0'
-  s.swift_versions = ['5.0']
+  s.swift_versions = ['5.3']
 
   s.source_files = s.name + '/Sources/**/*'
+
+  s.dependency 'TIFoundationUtils', s.version.to_s
+  s.dependency 'TINetworking', s.version.to_s
+  s.dependency 'Cache', "~> 6.0.0"
 end

--- a/TISwiftUtils/TISwiftUtils.podspec
+++ b/TISwiftUtils/TISwiftUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TISwiftUtils'
-  s.version          = '1.14.3'
+  s.version          = '1.15.0'
   s.summary          = 'Bunch of useful helpers for Swift development.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITableKitUtils/TITableKitUtils.podspec
+++ b/TITableKitUtils/TITableKitUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITableKitUtils'
-  s.version          = '1.14.3'
+  s.version          = '1.15.0'
   s.summary          = 'Set of helpers for TableKit classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIElements/TIUIElements.podspec
+++ b/TIUIElements/TIUIElements.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIElements'
-  s.version          = '1.14.3'
+  s.version          = '1.15.0'
   s.summary          = 'Bunch of useful protocols and views.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIKitCore/TIUIKitCore.podspec
+++ b/TIUIKitCore/TIUIKitCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIKitCore'
-  s.version          = '1.14.3'
+  s.version          = '1.15.0'
   s.summary          = 'Core UI elements: protocols, views and helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/project-scripts/push_to_podspecs.sh
+++ b/project-scripts/push_to_podspecs.sh
@@ -12,6 +12,7 @@ ORDERED_PODSPECS="../TISwiftUtils/TISwiftUtils.podspec
 ../TIUIElements/TIUIElements.podspec
 ../TITableKitUtils/TITableKitUtils.podspec
 ../TINetworking/TINetworking.podspec
+../TINetworking/TINetworkingCache.podspec
 ../TIMoyaNetworking/TIMoyaNetworking.podspec"
 
 for podspec_path in ${ORDERED_PODSPECS}; do


### PR DESCRIPTION
Теперь можно использовать SerializedRequest для сохранения и получения закешированных данных:



```swift
func getCart() async -> EndpointRequestResult<CartModel, ErrorResponse> {
    apiCallOrCached(for: .apiV3MobileCartGet())
}

func getOrders(page: Int = 1,
               count: Int = 20) async -> EndpointRequestResult<[Order], ErrorResponse> {

    apiCallOrCached(for: .apiV3MobileOrdersGet(page: page, count: count))
}

func apiCallOrCached<B: Encodable, S: Encodable>(for request: EndpointRequest<B, S>) async -> EndpointRequestResult<S, ErrorResponse> {
    let response = await networkService.process(recoverableRequest: request)

    do {
        let serializedRequest = try networkService.serialize(request: request)

        let endpointCache = try EndpointCacheService<S>(serializedRequest: serializedRequest,
                                                        cacheLifetime: 5 * 60, // 5 minutes
                                                        jsonCodingConfigurator: jsonCodingConfigurator)

        switch response {
        case let .success(content):
            endpointCache.cachedContent = content
        case let .failure(endpointError):
            if endpointError.isNetworkConnectionProblem, let cachedResponse = endpointCache.cachedContent {
                return .success(cachedResponse)
            }
        }
    } catch {
        return response
    }

    return response
}
```