### PR TITLE
feat: add error forwarding from error handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.16.2
+
+- **Update**: `DefaultRecoverableJsonNetworkService` now supports error forwarding from its error handlers to initial requests.
+
 ### 1.16.1
 
 - **Update**: `DateFormattersReusePool` and  `ISO8601DateFormattersReusePool` are now thread safe.

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "1.16.1"
+  s.version         = "1.16.2"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/TIAppleMapUtils/TIAppleMapUtils.podspec
+++ b/TIAppleMapUtils/TIAppleMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIAppleMapUtils'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Apple MapKit.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIFoundationUtils/TIFoundationUtils.podspec
+++ b/TIFoundationUtils/TIFoundationUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIFoundationUtils'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Set of helpers for Foundation framework classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIGoogleMapUtils/TIGoogleMapUtils.podspec
+++ b/TIGoogleMapUtils/TIGoogleMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIGoogleMapUtils'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Google Maps SDK.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIKeychainUtils/TIKeychainUtils.podspec
+++ b/TIKeychainUtils/TIKeychainUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIKeychainUtils'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Set of helpers for Keychain classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMapUtils/TIMapUtils.podspec
+++ b/TIMapUtils/TIMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMapUtils'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Set of helpers for map objects clustering and interacting.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMoyaNetworking/Sources/RecoverableNetworkService/AsyncEventHandler/AnyAsyncEventHandler.swift
+++ b/TIMoyaNetworking/Sources/RecoverableNetworkService/AsyncEventHandler/AnyAsyncEventHandler.swift
@@ -23,14 +23,16 @@
 import TISwiftUtils
 
 @available(iOS 13.0.0, *)
-public struct AnyAsyncEventHandler<EventType>: AsyncEventHandler {
-    private let processClosure: AsyncClosure<EventType, Bool>
+public struct AnyAsyncEventHandler<EventType, ResultType>: AsyncEventHandler {
+    private let processClosure: AsyncClosure<EventType, ResultType>
 
-    public init<Handler: AsyncEventHandler>(handler: Handler) where Handler.EventType == EventType {
+    public init<Handler: AsyncEventHandler>(handler: Handler)
+        where Handler.EventType == EventType, Handler.ResultType == ResultType {
+
         self.processClosure = handler.handle
     }
 
-    public func handle(_ event: EventType) async -> Bool {
+    public func handle(_ event: EventType) async -> ResultType {
         await processClosure(event)
     }
 }

--- a/TIMoyaNetworking/Sources/RecoverableNetworkService/AsyncEventHandler/AsyncEventHandler.swift
+++ b/TIMoyaNetworking/Sources/RecoverableNetworkService/AsyncEventHandler/AsyncEventHandler.swift
@@ -23,13 +23,14 @@
 @available(iOS 13.0.0, *)
 public protocol AsyncEventHandler {
     associatedtype EventType
+    associatedtype ResultType
 
-    func handle(_ event: EventType) async -> Bool
+    func handle(_ event: EventType) async -> ResultType
 }
 
 @available(iOS 13.0.0, *)
 public extension AsyncEventHandler {
-    func asAnyAsyncEventHandler() -> AnyAsyncEventHandler<EventType> {
+    func asAnyAsyncEventHandler() -> AnyAsyncEventHandler<EventType, ResultType> {
         .init(handler: self)
     }
 }

--- a/TIMoyaNetworking/Sources/RecoverableNetworkService/AsyncEventHandler/RecoverableErrorHandlerResult.swift
+++ b/TIMoyaNetworking/Sources/RecoverableNetworkService/AsyncEventHandler/RecoverableErrorHandlerResult.swift
@@ -20,21 +20,8 @@
 //  THE SOFTWARE.
 //
 
-@available(iOS 13.0.0, *)
-public struct AsyncEventHandlingChain<Handler: AsyncEventHandler>: AsyncEventHandler {
-    private let handlers: [Handler]
-
-    public init(handlers: [Handler]) {
-        self.handlers = handlers
-    }
-
-    public func handle(_ event: Handler.EventType) async -> Bool {
-        for handler in handlers {
-            if await handler.handle(event) {
-                return true
-            }
-        }
-
-        return false
-    }
+public enum RecoverableErrorHandlerResult<ErrorType: Error> {
+    case skipError
+    case recoverRequest
+    case forwardError(ErrorType)
 }

--- a/TIMoyaNetworking/TIMoyaNetworking.podspec
+++ b/TIMoyaNetworking/TIMoyaNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMoyaNetworking'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Moya + Swagger network service.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworking/TINetworking.podspec
+++ b/TINetworking/TINetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworking'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Swagger-frendly networking layer helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworkingCache/TINetworkingCache.podspec
+++ b/TINetworkingCache/TINetworkingCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworkingCache'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Caching results of EndpointRequests.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIPagination/TIPagination.podspec
+++ b/TIPagination/TIPagination.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIPagination'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Generic pagination component.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TISwiftUtils/TISwiftUtils.podspec
+++ b/TISwiftUtils/TISwiftUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TISwiftUtils'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Bunch of useful helpers for Swift development.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITableKitUtils/TITableKitUtils.podspec
+++ b/TITableKitUtils/TITableKitUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITableKitUtils'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Set of helpers for TableKit classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITransitions/TITransitions.podspec
+++ b/TITransitions/TITransitions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITransitions'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Set of custom transitions to present controller. '
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIElements/TIUIElements.podspec
+++ b/TIUIElements/TIUIElements.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIElements'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Bunch of useful protocols and views.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIKitCore/TIUIKitCore.podspec
+++ b/TIUIKitCore/TIUIKitCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIKitCore'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Core UI elements: protocols, views and helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIYandexMapUtils/TIYandexMapUtils.podspec
+++ b/TIYandexMapUtils/TIYandexMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIYandexMapUtils'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Yandex Maps SDK.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
В `DefaultRecoverableJsonNetworkService` добавлена возможность пробрасывать ошибки из обработчиков в начальный запрос.

Пример использования:
1. У нас есть обработчик токенов авторизации, который пытается обновить токены, если приходит ошибка об их просрочке.
2. Мы отправляем какой-нибудь запрос, в ответе приходит ошибка просроченных токенов.
3. Мы отправляем запрос на обновление токенов, но этот запрос фейлится ошибкой сервера (какой-нибудь 500 с текстом ошибки).
4. Эту ошибку  нам надо пробросить в основной запрос и отобразить в подсказке/заглушке.