### PR TITLE
feat: Asynchronous request preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.22.0
+
+- **Update**: Asynchronous request preprocessing
+
 ### 1.21.0
 
 - **Update**: `AsyncEventHandler` was replaced with `EndpointRequestRetrier`

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "1.21.0"
+  s.version         = "1.22.0"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/TIAppleMapUtils/TIAppleMapUtils.podspec
+++ b/TIAppleMapUtils/TIAppleMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIAppleMapUtils'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Apple MapKit.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIAuth/TIAuth.podspec
+++ b/TIAuth/TIAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIAuth'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Login, registration, confirmation and other related actions'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIFoundationUtils/Cancellables/Sources/Cancellables.swift
+++ b/TIFoundationUtils/Cancellables/Sources/Cancellables.swift
@@ -29,3 +29,20 @@ public struct Cancellables {
         ScopeCancellable(scopeCancellableClosure: scopeCancellableClosure)
     }
 }
+
+@available(iOS 13.0.0, *)
+public func withTaskCancellableClosure<T>(closure: (@escaping (T) -> Void) -> Cancellable) async -> T {
+    let cancellableBag = BaseCancellableBag()
+
+    return await withTaskCancellationHandler(handler: {
+        cancellableBag.cancel()
+    }, operation: {
+        await withCheckedContinuation { continuation in
+            closure {
+                continuation.resume(returning: $0)
+            }
+            .add(to: cancellableBag)
+        }
+    })
+}
+

--- a/TIFoundationUtils/TIFoundationUtils.podspec
+++ b/TIFoundationUtils/TIFoundationUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIFoundationUtils'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Set of helpers for Foundation framework classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIGoogleMapUtils/TIGoogleMapUtils.podspec
+++ b/TIGoogleMapUtils/TIGoogleMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIGoogleMapUtils'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Google Maps SDK.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIKeychainUtils/TIKeychainUtils.podspec
+++ b/TIKeychainUtils/TIKeychainUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIKeychainUtils'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Set of helpers for Keychain classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMapUtils/TIMapUtils.podspec
+++ b/TIMapUtils/TIMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMapUtils'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Set of helpers for map objects clustering and interacting.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMoyaNetworking/TIMoyaNetworking.podspec
+++ b/TIMoyaNetworking/TIMoyaNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMoyaNetworking'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Moya + Swagger network service.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworking/Sources/ApiInteractor/ApiInteractor.swift
+++ b/TINetworking/Sources/ApiInteractor/ApiInteractor.swift
@@ -49,21 +49,13 @@ public extension ApiInteractor {
                                                                      mapFailure: @escaping Closure<F, R>,
                                                                      mapNetworkError: @escaping Closure<NetworkError, R>) async -> R {
 
-        let cancellableBag = BaseCancellableBag()
-
-        return await withTaskCancellationHandler(handler: {
-            cancellableBag.cancel()
-        }, operation: {
-            await withCheckedContinuation { continuation in
-                process(request: request,
-                        mapSuccess: mapSuccess,
-                        mapFailure: mapFailure,
-                        mapNetworkError: mapNetworkError) {
-
-                    continuation.resume(returning: $0)
-                }
-                .add(to: cancellableBag)
+        await withTaskCancellableClosure { completion in
+            process(request: request,
+                    mapSuccess: mapSuccess,
+                    mapFailure: mapFailure,
+                    mapNetworkError: mapNetworkError) {
+                completion($0)
             }
-        })
+        }
     }
 }

--- a/TINetworking/Sources/Interceptors/EndpointRequestRetrier.swift
+++ b/TINetworking/Sources/Interceptors/EndpointRequestRetrier.swift
@@ -35,17 +35,10 @@ public protocol EndpointRequestRetrier {
 @available(iOS 13.0.0, *)
 public extension EndpointRequestRetrier {
     func validateAndRepair(errorResults: [ErrorResult]) async -> EndpointRetryResult {
-        let cancellableBag = BaseCancellableBag()
-
-        return await withTaskCancellationHandler(handler: {
-            cancellableBag.cancel()
-        }, operation: {
-            await withCheckedContinuation { continuation in
-                validateAndRepair(errorResults: errorResults) {
-                    continuation.resume(returning: $0)
-                }
-                .add(to: cancellableBag)
+        await withTaskCancellableClosure { completion in
+            validateAndRepair(errorResults: errorResults) {
+                completion($0)
             }
-        })
+        }
     }
 }

--- a/TINetworking/Sources/Interceptors/EndpointResponseTokenInterceptor.swift
+++ b/TINetworking/Sources/Interceptors/EndpointResponseTokenInterceptor.swift
@@ -29,7 +29,7 @@ open class EndpointResponseTokenInterceptor<AE, NE>: DefaultTokenInterceptor<End
 
     private let isTokenInvalidErrorResultClosure: IsTokenInvalidErrorResultClosure
 
-    public init(isTokenInvalidClosure: @escaping IsTokenInvalidClosure,
+    public init(isTokenInvalidClosure: @escaping ShouldRefreshTokenClosure,
                 refreshTokenClosure: @escaping RefreshTokenClosure,
                 isTokenInvalidErrorResultClosure: @escaping IsTokenInvalidErrorResultClosure,
                 requestModificationClosure: RequestModificationClosure? = nil) {

--- a/TINetworking/Sources/RequestPreprocessors/EndpointRequestPreprocessor.swift
+++ b/TINetworking/Sources/RequestPreprocessors/EndpointRequestPreprocessor.swift
@@ -20,6 +20,20 @@
 //  THE SOFTWARE.
 //
 
+import TIFoundationUtils
+
 public protocol EndpointRequestPreprocessor {
-    func preprocess<B,S>(request: EndpointRequest<B,S>) throws -> EndpointRequest<B,S>
+    func preprocess<B,S>(request: EndpointRequest<B,S>,
+                         completion: @escaping (Result<EndpointRequest<B,S>, Error>) -> Void) -> Cancellable
+}
+
+@available(iOS 13.0.0, *)
+public extension EndpointRequestPreprocessor {
+    func preprocess<B,S>(request: EndpointRequest<B,S>) async -> Result<EndpointRequest<B,S>, Error> {
+        await withTaskCancellableClosure { completion in
+            preprocess(request: request) {
+                completion($0)
+            }
+        }
+    }
 }

--- a/TINetworking/Sources/RequestPreprocessors/EndpointSecurityRequestPreprocessor.swift
+++ b/TINetworking/Sources/RequestPreprocessors/EndpointSecurityRequestPreprocessor.swift
@@ -20,8 +20,21 @@
 //  THE SOFTWARE.
 //
 
+import TIFoundationUtils
+
 public protocol SecuritySchemePreprocessor {
-    func preprocess<B,S>(request: EndpointRequest<B,S>, using security: SecurityScheme) throws -> EndpointRequest<B,S>
+    func preprocess<B,S>(request: EndpointRequest<B,S>,
+                         using security: SecurityScheme,
+                         completion: @escaping (Result<EndpointRequest<B,S>, Error>) -> Void) -> Cancellable
 }
 
-
+@available(iOS 13.0.0, *)
+public extension SecuritySchemePreprocessor {
+    func preprocess<B,S>(request: EndpointRequest<B,S>, using security: SecurityScheme) async -> Result<EndpointRequest<B,S>, Error> {
+        await withTaskCancellableClosure { completion in
+            preprocess(request: request, using: security) {
+                completion($0)
+            }
+        }
+    }
+}

--- a/TINetworking/TINetworking.podspec
+++ b/TINetworking/TINetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworking'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Swagger-frendly networking layer helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworkingCache/TINetworkingCache.podspec
+++ b/TINetworkingCache/TINetworkingCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworkingCache'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Caching results of EndpointRequests.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIPagination/TIPagination.podspec
+++ b/TIPagination/TIPagination.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIPagination'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Generic pagination component.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TISwiftUICore/TISwiftUICore.podspec
+++ b/TISwiftUICore/TISwiftUICore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TISwiftUICore'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Core UI elements: protocols, views and helpers..'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TISwiftUtils/TISwiftUtils.podspec
+++ b/TISwiftUtils/TISwiftUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TISwiftUtils'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Bunch of useful helpers for Swift development.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITableKitUtils/TITableKitUtils.podspec
+++ b/TITableKitUtils/TITableKitUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITableKitUtils'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Set of helpers for TableKit classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITransitions/TITransitions.podspec
+++ b/TITransitions/TITransitions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITransitions'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Set of custom transitions to present controller. '
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIElements/TIUIElements.podspec
+++ b/TIUIElements/TIUIElements.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIElements'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Bunch of useful protocols and views.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIKitCore/TIUIKitCore.podspec
+++ b/TIUIKitCore/TIUIKitCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIKitCore'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Core UI elements: protocols, views and helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIYandexMapUtils/TIYandexMapUtils.podspec
+++ b/TIYandexMapUtils/TIYandexMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIYandexMapUtils'
-  s.version          = '1.21.0'
+  s.version          = '1.22.0'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Yandex Maps SDK.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
Поддержка асинхронных запросов для security схем OpenAPI

```swift
let accessTokenPreprocessor = DefaultSecuritySchemePreprocessor { [renewTokenService, tokenService] completion in
    renewTokenService.validateAndRepair { _ in
        completion(tokenService.accessToken?.value)
    }
}

networkService.register(securityPreprocessors: [
    OpenAPI.SecurityNames.access_token: accessTokenPreprocessor
])
```