### PR TITLE
Pass url to request error

### DIFF
--- a/Sources/Enums/RequestError.swift
+++ b/Sources/Enums/RequestError.swift
@@ -31,8 +31,8 @@ import Alamofire
 /// - mapping: Errors that occurs during mapping json into model.
 public enum RequestError: Error {
 
-    case noConnection
-    case network(error: Error, response: Data?)
-    case invalidResponse(error: AFError, response: Data?)
-    case mapping(error: Error, response: Data)
+    case noConnection(url: String?)
+    case network(error: Error, response: Data?, url: String?)
+    case invalidResponse(error: AFError, response: Data?, url: String?)
+    case mapping(error: Error, response: Data, url: String?)
 }

--- a/Sources/Extensions/Alamofire/DataRequest+Extensions.swift
+++ b/Sources/Extensions/Alamofire/DataRequest+Extensions.swift
@@ -80,9 +80,9 @@ public extension ObservableType where Element == DataRequest {
     ///
     /// - Parameter statusCodes: set of status codes to validate
     /// - Returns: Observable on self
-    func validate(statusCodes: Set<Int>) -> Observable<Element> {
+    func validate(statusCodes: Set<Int>, url: String? = nil) -> Observable<Element> {
         map { $0.validate(statusCode: statusCodes) }
-            .catchAsRequestError()
+            .catchAsRequestError(url: url)
     }
 }
 
@@ -114,7 +114,8 @@ private extension ObservableType where Element == ServerResponse {
 
 private extension ObservableType {
 
-    func catchAsRequestError(with request: DataRequest? = nil) -> Observable<Element> {
+    func catchAsRequestError(with request: DataRequest? = nil,
+                             url: String? = nil) -> Observable<Element> {
         self.catch { error in
             let resultError: RequestError
             let response = request?.data

--- a/Sources/Extensions/Alamofire/DataRequest+Extensions.swift
+++ b/Sources/Extensions/Alamofire/DataRequest+Extensions.swift
@@ -93,7 +93,9 @@ private extension ObservableType where Element == ServerResponse {
             do {
                 return try transform($0)
             } catch {
-                throw RequestError.mapping(error: error, response: $0.1)
+                throw RequestError.mapping(error: error,
+                                           response: $0.1,
+                                           url: $0.0.url?.absoluteString)
             }
         }
     }
@@ -103,10 +105,14 @@ private extension ObservableType where Element == ServerResponse {
             do {
                 return try transform((response, result))
                     .catch {
-                        throw RequestError.mapping(error: $0, response: result)
+                        throw RequestError.mapping(error: $0,
+                                                   response: result,
+                                                   url: response.url?.absoluteString)
                     }
             } catch {
-                throw RequestError.mapping(error: error, response: result)
+                throw RequestError.mapping(error: error,
+                                           response: result,
+                                           url: response.url?.absoluteString)
             }
         }
     }
@@ -127,10 +133,10 @@ private extension ObservableType {
             case let urlError as URLError:
                 switch urlError.code {
                 case .notConnectedToInternet:
-                    resultError = .noConnection
+                    resultError = .noConnection(url: url)
 
                 default:
-                    resultError = .network(error: urlError, response: response)
+                    resultError = .network(error: urlError, response: response, url: url)
                 }
 
             case let afError as AFError:
@@ -138,21 +144,21 @@ private extension ObservableType {
                 case let .sessionTaskFailed(error):
                     switch error {
                     case let urlError as URLError where urlError.code == .notConnectedToInternet:
-                        resultError = .noConnection
+                        resultError = .noConnection(url: url)
 
                     default:
-                        resultError = .network(error: error, response: response)
+                        resultError = .network(error: error, response: response, url: url)
                     }
 
                 case .responseSerializationFailed, .responseValidationFailed:
-                    resultError = .invalidResponse(error: afError, response: response)
+                    resultError = .invalidResponse(error: afError, response: response, url: url)
 
                 default:
-                    resultError = .network(error: afError, response: response)
+                    resultError = .network(error: afError, response: response, url: url)
                 }
 
             default:
-                resultError = .network(error: error, response: response)
+                resultError = .network(error: error, response: response, url: url)
             }
 
             throw resultError

--- a/Sources/Extensions/Alamofire/SessionManager+Extensions.swift
+++ b/Sources/Extensions/Alamofire/SessionManager+Extensions.swift
@@ -117,7 +117,8 @@ public extension Reactive where Base: SessionManager {
             }
 
             return requestObservable
-                .validate(statusCodes: self.base.acceptableStatusCodes.union(additionalValidStatusCodes))
+                .validate(statusCodes: self.base.acceptableStatusCodes.union(additionalValidStatusCodes),
+                          url: url.absoluteString)
         }
     }
 
@@ -191,7 +192,8 @@ public extension Reactive where Base: SessionManager {
 
                 return self.upload(data, urlRequest: urlRequest)
                     .map { $0 as DataRequest }
-                    .validate(statusCodes: self.base.acceptableStatusCodes.union(additionalValidStatusCodes))
+                    .validate(statusCodes: self.base.acceptableStatusCodes.union(additionalValidStatusCodes),
+                              url: try? requestParameters.url.asURL().absoluteString)
                     .flatMap {
                         $0.rx.apiResponse(mappingQueue: self.base.mappingQueue, decoder: decoder)
                     }

--- a/Sources/Extensions/Error/Error+NetworkExtensions.swift
+++ b/Sources/Extensions/Error/Error+NetworkExtensions.swift
@@ -34,7 +34,7 @@ public extension Error {
     /// - Returns: optional target object
     /// - Throws: an error during decoding
     func handleMappingError<T: Decodable>(with decoder: JSONDecoder = JSONDecoder()) throws -> T? {
-        guard let self = requestError, case .mapping(_, let response) = self else {
+        guard let self = requestError, case .mapping(_, let response, _) = self else {
             return nil
         }
 


### PR DESCRIPTION
## Передача url запроса в ошибку

Необходимо все ошибки запросов трекать в аналитику в формате **url + errorCode**. ErrorCode сейчас передается в определенном кейсе `RequestError` (а именно в `invalidResponse`, который содержит `AFError` с кодом ошибки), а вот url приходится пробрасывать своими силами.

Адаптация работы с данными, передаваемыми в ошибку, предполагается со стороны проекта.

Например, можно сделать дополнительный Rx оператор для автоматического отлова ошибок и трекинга:

> **Warning** Пример не работает, рассматривается в качестве песвдокода

```swift
extension PrimitiveSequence where Trait == SingleTrait {
    func trackError() -> PrimitiveSequence<Trait, Element> {
        `do`(onError: { error in
            guard let err = error as? RequestError else {
                return
            }

            switch err {
            case let .noConnection(url):
                print("[DEBUG] Catch request error: \(url)")
            case let .network(_, _, url):
                print("[DEBUG] Catch request error: \(url)")
            case let .invalidResponse(error, _, url):
                print("[DEBUG] Catch request error with code: \(error.responseCode) and url: \(url)")
            case let .mapping(_, _, url):
                print("[DEBUG] Catch request error: \(url)")
            }
        })
    }
}
```

Затем использовать при обработке запроса:

```swift
private func obtainPersonalData() {
     personalService.obtainPersonalInfoData()
         .observe(on: MainScheduler.instance)
         .trackError()
         .subscribe(onSuccess: { [weak self] in
            ...
         }, onFailure: { [weak self] in
            ...
         })
         .disposed(by: disposeBag)
}
```
