### PR TITLE
Weak target reference capturing in `RefreshControl` fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.27.1
+
+- **Fix**: Weak target reference in `RefreshControl`
+
 ### 1.27.0
 
 - **Add**: Tag like filter collection view

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "1.27.0"
+  s.version         = "1.27.1"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/TIAppleMapUtils/TIAppleMapUtils.podspec
+++ b/TIAppleMapUtils/TIAppleMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIAppleMapUtils'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Apple MapKit.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIAuth/TIAuth.podspec
+++ b/TIAuth/TIAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIAuth'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Login, registration, confirmation and other related actions'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIEcommerce/TIEcommerce.podspec
+++ b/TIEcommerce/TIEcommerce.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIEcommerce'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Cart, products, promocodes, bonuses and other related actions'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIFoundationUtils/TIFoundationUtils.podspec
+++ b/TIFoundationUtils/TIFoundationUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIFoundationUtils'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Set of helpers for Foundation framework classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIGoogleMapUtils/TIGoogleMapUtils.podspec
+++ b/TIGoogleMapUtils/TIGoogleMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIGoogleMapUtils'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Google Maps SDK.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIKeychainUtils/TIKeychainUtils.podspec
+++ b/TIKeychainUtils/TIKeychainUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIKeychainUtils'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Set of helpers for Keychain classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMapUtils/TIMapUtils.podspec
+++ b/TIMapUtils/TIMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMapUtils'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Set of helpers for map objects clustering and interacting.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMoyaNetworking/TIMoyaNetworking.podspec
+++ b/TIMoyaNetworking/TIMoyaNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMoyaNetworking'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Moya + Swagger network service.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworking/TINetworking.podspec
+++ b/TINetworking/TINetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworking'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Swagger-frendly networking layer helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworkingCache/TINetworkingCache.podspec
+++ b/TINetworkingCache/TINetworkingCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworkingCache'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Caching results of EndpointRequests.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIPagination/TIPagination.podspec
+++ b/TIPagination/TIPagination.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIPagination'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Generic pagination component.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TISwiftUICore/TISwiftUICore.podspec
+++ b/TISwiftUICore/TISwiftUICore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TISwiftUICore'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Core UI elements: protocols, views and helpers..'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TISwiftUtils/TISwiftUtils.podspec
+++ b/TISwiftUtils/TISwiftUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TISwiftUtils'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Bunch of useful helpers for Swift development.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITableKitUtils/TITableKitUtils.podspec
+++ b/TITableKitUtils/TITableKitUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITableKitUtils'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Set of helpers for TableKit classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITransitions/TITransitions.podspec
+++ b/TITransitions/TITransitions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITransitions'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Set of custom transitions to present controller. '
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIElements/Sources/Views/RefreshControl/RefreshControl.swift
+++ b/TIUIElements/Sources/Views/RefreshControl/RefreshControl.swift
@@ -1,8 +1,10 @@
 import UIKit
 
 open class RefreshControl: UIRefreshControl {
+
     private var action: Selector?
-    private var target: NSObjectProtocol?
+
+    private weak var target: NSObjectProtocol?
 
     // Handle .valueChanged event of refresh control
     public override func addTarget(_ target: Any?, action: Selector, for controlEvents: UIControl.Event) {

--- a/TIUIElements/TIUIElements.podspec
+++ b/TIUIElements/TIUIElements.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIElements'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Bunch of useful protocols and views.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIKitCore/TIUIKitCore.podspec
+++ b/TIUIKitCore/TIUIKitCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIKitCore'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Core UI elements: protocols, views and helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIYandexMapUtils/TIYandexMapUtils.podspec
+++ b/TIYandexMapUtils/TIYandexMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIYandexMapUtils'
-  s.version          = '1.27.0'
+  s.version          = '1.27.1'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Yandex Maps SDK.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
## Исправление захвата слабой ссылки на `target` для `RefreshControl`

- Захват сильной ссылки ранее вызывал утечку памяти для всех контроллеров, использовавших `RefreshControl` из `TIUIElements`

### Результат

### "До" - сильная ссылка на `target` - учетка памяти

https://user-images.githubusercontent.com/37587023/196417353-1c995b7f-edca-4967-bba3-4e9463db8cc6.mov

### "После" - слабая ссылка на `target` - утечка памяти `отсутствует`

https://user-images.githubusercontent.com/37587023/196417676-dc3f1c44-b775-439c-835f-251dc96fab1d.mov

