### PR TITLE
feat: URLInteractiveTextView for terms and conditions hints in login flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.31.0
+
+- **Added**: `URLInteractiveTextView` for terms and conditions hints in login flow
+
 ### 1.30.0
 
 - **Added**: Base classes for encryption and decryption user token with pin code or biometry

--- a/LeadKit.podspec
+++ b/LeadKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = "LeadKit"
-  s.version         = "1.30.0"
+  s.version         = "1.31.0"
   s.summary         = "iOS framework with a bunch of tools for rapid development"
   s.homepage        = "https://github.com/TouchInstinct/LeadKit"
   s.license         = "Apache License, Version 2.0"

--- a/TIAppleMapUtils/TIAppleMapUtils.podspec
+++ b/TIAppleMapUtils/TIAppleMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIAppleMapUtils'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Apple MapKit.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIAuth/TIAuth.podspec
+++ b/TIAuth/TIAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIAuth'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Login, registration, confirmation and other related actions'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIEcommerce/TIEcommerce.podspec
+++ b/TIEcommerce/TIEcommerce.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIEcommerce'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Cart, products, promocodes, bonuses and other related actions'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIFoundationUtils/TIFoundationUtils.podspec
+++ b/TIFoundationUtils/TIFoundationUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIFoundationUtils'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Set of helpers for Foundation framework classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIGoogleMapUtils/TIGoogleMapUtils.podspec
+++ b/TIGoogleMapUtils/TIGoogleMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIGoogleMapUtils'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Google Maps SDK.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIKeychainUtils/TIKeychainUtils.podspec
+++ b/TIKeychainUtils/TIKeychainUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIKeychainUtils'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Set of helpers for Keychain classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TILogging/Sources/Views/LoggerList/LogsListViewController.swift
+++ b/TILogging/Sources/Views/LoggerList/LogsListViewController.swift
@@ -26,7 +26,7 @@ import OSLog
 import UIKit
 
 @available(iOS 15, *)
-open class LogsListViewController: BaseInitializeableViewController,
+open class LogsListViewController: BaseInitializableViewController,
                                    LogsListViewOutput,
                                    AlertPresentationContext,
                                    UISearchBarDelegate,

--- a/TILogging/Sources/Views/LoggerWindow/LoggingTogglingViewController.swift
+++ b/TILogging/Sources/Views/LoggerWindow/LoggingTogglingViewController.swift
@@ -24,7 +24,7 @@ import TIUIKitCore
 import UIKit
 
 @available(iOS 15, *)
-open class LoggingTogglingViewController: BaseInitializeableViewController {
+open class LoggingTogglingViewController: BaseInitializableViewController {
 
     private var initialCenter = CGPoint()
 

--- a/TILogging/TILogging.podspec
+++ b/TILogging/TILogging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TILogging'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Logging API'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMapUtils/TIMapUtils.podspec
+++ b/TIMapUtils/TIMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMapUtils'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Set of helpers for map objects clustering and interacting.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIMoyaNetworking/TIMoyaNetworking.podspec
+++ b/TIMoyaNetworking/TIMoyaNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIMoyaNetworking'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Moya + Swagger network service.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworking/TINetworking.podspec
+++ b/TINetworking/TINetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworking'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Swagger-frendly networking layer helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TINetworkingCache/TINetworkingCache.podspec
+++ b/TINetworkingCache/TINetworkingCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TINetworkingCache'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Caching results of EndpointRequests.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIPagination/TIPagination.podspec
+++ b/TIPagination/TIPagination.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIPagination'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Generic pagination component.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TISwiftUICore/TISwiftUICore.podspec
+++ b/TISwiftUICore/TISwiftUICore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TISwiftUICore'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Core UI elements: protocols, views and helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TISwiftUtils/TISwiftUtils.podspec
+++ b/TISwiftUtils/TISwiftUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TISwiftUtils'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Bunch of useful helpers for Swift development.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITableKitUtils/TITableKitUtils.podspec
+++ b/TITableKitUtils/TITableKitUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITableKitUtils'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Set of helpers for TableKit classes.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TITransitions/TITransitions.podspec
+++ b/TITransitions/TITransitions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TITransitions'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Set of custom transitions to present controller. '
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIElements/Sources/Views/BaseInitializableTextView.swift
+++ b/TIUIElements/Sources/Views/BaseInitializableTextView.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2021 Touch Instinct
+//  Copyright (c) 2022 Touch Instinct
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the Software), to deal
@@ -20,21 +20,23 @@
 //  THE SOFTWARE.
 //
 
-import UIKit.UIViewController
+import UIKit.UITextView
+import TIUIKitCore
 
-open class BaseInitializeableViewController: UIViewController, InitializeableViewController {
+open class BaseInitializableTextView: UITextView, InitializableViewProtocol {
+    public override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
 
-    override open func viewDidLoad() {
-        super.viewDidLoad()
-
-        onViewDidLoad()
+        initializeView()
     }
 
-    open func onViewDidLoad() {
-        initializeController()
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+
+        initializeView()
     }
 
-    // MARK: - InitializeableController
+    // MARK: - InitializableView
 
     open func addViews() {
         // override in subclass
@@ -53,10 +55,6 @@ open class BaseInitializeableViewController: UIViewController, InitializeableVie
     }
 
     open func localize() {
-        // override in subclass
-    }
-
-    open func configureBarButtons() {
         // override in subclass
     }
 }

--- a/TIUIElements/Sources/Views/BaseInitializeableTextView.swift
+++ b/TIUIElements/Sources/Views/BaseInitializeableTextView.swift
@@ -1,0 +1,60 @@
+//
+//  Copyright (c) 2022 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit.UITextView
+import TIUIKitCore
+
+open class BaseInitializeableTextView: UITextView, InitializableViewProtocol {
+    public override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+
+        initializeView()
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+
+        initializeView()
+    }
+
+    // MARK: - InitializableView
+
+    open func addViews() {
+        // override in subclass
+    }
+
+    open func configureLayout() {
+        // override in subclass
+    }
+
+    open func bindViews() {
+        // override in subclass
+    }
+
+    open func configureAppearance() {
+        // override in subclass
+    }
+
+    open func localize() {
+        // override in subclass
+    }
+}

--- a/TIUIElements/Sources/Views/URLInteractiveTextView/DefaultUITextViewURLInteractionHandler.swift
+++ b/TIUIElements/Sources/Views/URLInteractiveTextView/DefaultUITextViewURLInteractionHandler.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright (c) 2022 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit.UITextView
+import TISwiftUtils
+
+open class DefaultUITextViewURLInteractionHandler: NSObject, UITextViewURLInteractionHandler {
+    public var urlInteractionHandler: ParameterClosure<URL>?
+
+    public init(urlInteractionHandler: ParameterClosure<URL>?) {
+        self.urlInteractionHandler = urlInteractionHandler
+    }
+
+    open func textView(_ textView: UITextView,
+                       shouldInteractWith URL: URL,
+                       in characterRange: NSRange,
+                       interaction: UITextItemInteraction) -> Bool {
+
+        urlInteractionHandler?(URL)
+
+        return false
+    }
+}

--- a/TIUIElements/Sources/Views/URLInteractiveTextView/UITextView+InteractiveParts.swift
+++ b/TIUIElements/Sources/Views/URLInteractiveTextView/UITextView+InteractiveParts.swift
@@ -56,7 +56,10 @@ public extension UITextView {
                 return InteractiveRange(range: range, url: url)
             }
             .forEach { range, url in
-                mutableAttributedText.addAttributes(interactiveAttributes, range: NSRange(range, in: text))
+                var partLinkAttributes = interactiveAttributes
+                partLinkAttributes.updateValue(url, forKey: .link)
+
+                mutableAttributedText.addAttributes(partLinkAttributes, range: NSRange(range, in: text))
             }
 
         attributedText = mutableAttributedText

--- a/TIUIElements/Sources/Views/URLInteractiveTextView/UITextView+InteractiveParts.swift
+++ b/TIUIElements/Sources/Views/URLInteractiveTextView/UITextView+InteractiveParts.swift
@@ -48,8 +48,8 @@ public extension UITextView {
         interactiveParts
             .compactMap { interactivePart -> InteractiveRange? in
                 guard let range = text.range(of: interactivePart.text),
-                      let url = interactivePart.url
-                else {
+                      let url = interactivePart.url else {
+
                     return nil
                 }
 

--- a/TIUIElements/Sources/Views/URLInteractiveTextView/UITextView+InteractiveParts.swift
+++ b/TIUIElements/Sources/Views/URLInteractiveTextView/UITextView+InteractiveParts.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright (c) 2022 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit.UITextView
+import TIUIKitCore
+
+public extension UITextView {
+    private typealias InteractiveRange = (range: Range<String.Index>, url: URL)
+
+    struct InteractivePart {
+        public let text: String
+        public let url: URL?
+
+        public init(text: String, url: URL?) {
+            self.text = text
+            self.url = url
+        }
+    }
+
+    func set(text: String,
+             primaryTextStyle: BaseTextAttributes,
+             interactiveParts: [InteractivePart],
+             interactivePartsStyle: BaseTextAttributes) {
+
+        let mutableAttributedText = NSMutableAttributedString(string: text, attributes: primaryTextStyle.attributedStringAttributes)
+
+        let interactiveAttributes = interactivePartsStyle.attributedStringAttributes
+
+        interactiveParts
+            .compactMap { interactivePart -> InteractiveRange? in
+                guard let range = text.range(of: interactivePart.text),
+                      let url = interactivePart.url
+                else {
+                    return nil
+                }
+
+                return InteractiveRange(range: range, url: url)
+            }
+            .forEach { range, url in
+                mutableAttributedText.addAttributes(interactiveAttributes, range: NSRange(range, in: text))
+            }
+
+        attributedText = mutableAttributedText
+    }
+}

--- a/TIUIElements/Sources/Views/URLInteractiveTextView/UITextViewURLInteractionHandler.swift
+++ b/TIUIElements/Sources/Views/URLInteractiveTextView/UITextViewURLInteractionHandler.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright (c) 2022 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit.UITextView
+import TISwiftUtils
+
+public protocol UITextViewURLInteractionHandler: UITextViewDelegate {
+    var urlInteractionHandler: ParameterClosure<URL>? { get set }
+}

--- a/TIUIElements/Sources/Views/URLInteractiveTextView/URLInteractiveTextView.swift
+++ b/TIUIElements/Sources/Views/URLInteractiveTextView/URLInteractiveTextView.swift
@@ -1,0 +1,53 @@
+//
+//  Copyright (c) 2022 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit.UIGeometry
+import TIUIKitCore
+
+open class URLInteractiveTextView: BaseInitializeableTextView, ConfigurableView {
+    public var interactionHandler: UITextViewURLInteractionHandler? {
+        didSet {
+            delegate = interactionHandler
+        }
+    }
+
+    open override func configureAppearance() {
+        super.configureAppearance()
+
+        isEditable = false
+
+        textContainerInset = UIEdgeInsets(top: .zero,
+                                          left: -textContainer.lineFragmentPadding,
+                                          bottom: .zero,
+                                          right: -textContainer.lineFragmentPadding)
+    }
+
+    public func configure(with viewModel: URLInteractiveTextViewModel) {
+        set(text: viewModel.text,
+            primaryTextStyle: viewModel.primaryTextStyle,
+            interactiveParts: viewModel.interactiveParts,
+            interactivePartsStyle: viewModel.interactivePartsStyle)
+
+        interactionHandler = viewModel.interactionHandler
+    }
+
+}

--- a/TIUIElements/Sources/Views/URLInteractiveTextView/URLInteractiveTextView.swift
+++ b/TIUIElements/Sources/Views/URLInteractiveTextView/URLInteractiveTextView.swift
@@ -49,5 +49,4 @@ open class URLInteractiveTextView: BaseInitializableTextView, ConfigurableView {
 
         interactionHandler = viewModel.interactionHandler
     }
-
 }

--- a/TIUIElements/Sources/Views/URLInteractiveTextView/URLInteractiveTextView.swift
+++ b/TIUIElements/Sources/Views/URLInteractiveTextView/URLInteractiveTextView.swift
@@ -23,7 +23,7 @@
 import UIKit.UIGeometry
 import TIUIKitCore
 
-open class URLInteractiveTextView: BaseInitializeableTextView, ConfigurableView {
+open class URLInteractiveTextView: BaseInitializableTextView, ConfigurableView {
     public var interactionHandler: UITextViewURLInteractionHandler? {
         didSet {
             delegate = interactionHandler

--- a/TIUIElements/Sources/Views/URLInteractiveTextView/URLInteractiveTextViewModel.swift
+++ b/TIUIElements/Sources/Views/URLInteractiveTextView/URLInteractiveTextViewModel.swift
@@ -1,0 +1,59 @@
+//
+//  Copyright (c) 2022 Touch Instinct
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the Software), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import TISwiftUtils
+import TIUIKitCore
+import UIKit.UITextView
+
+open class URLInteractiveTextViewModel {
+    public var text: String
+    public var primaryTextStyle: BaseTextAttributes
+    public var interactiveParts: [UITextView.InteractivePart]
+    public var interactivePartsStyle: BaseTextAttributes
+    public var interactionHandler: UITextViewURLInteractionHandler?
+
+    public init(text: String,
+                primaryTextStyle: BaseTextAttributes,
+                interactiveParts: [UITextView.InteractivePart],
+                interactivePartsStyle: BaseTextAttributes,
+                interactionHandler: UITextViewURLInteractionHandler?) {
+
+        self.text = text
+        self.primaryTextStyle = primaryTextStyle
+        self.interactiveParts = interactiveParts
+        self.interactivePartsStyle = interactivePartsStyle
+        self.interactionHandler = interactionHandler
+    }
+
+    convenience init(text: String,
+                     primaryTextStyle: BaseTextAttributes,
+                     interactiveParts: [UITextView.InteractivePart],
+                     interactivePartsStyle: BaseTextAttributes,
+                     urlInteractionHandler: ParameterClosure<URL>?) {
+
+        self.init(text: text,
+                  primaryTextStyle: primaryTextStyle,
+                  interactiveParts: interactiveParts,
+                  interactivePartsStyle: interactivePartsStyle,
+                  interactionHandler: DefaultUITextViewURLInteractionHandler(urlInteractionHandler: urlInteractionHandler))
+    }
+}

--- a/TIUIElements/TIUIElements.podspec
+++ b/TIUIElements/TIUIElements.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIElements'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Bunch of useful protocols and views.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIUIKitCore/Sources/InitializableView/InitializableViewController.swift
+++ b/TIUIKitCore/Sources/InitializableView/InitializableViewController.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2022 Touch Instinct
+//  Copyright (c) 2021 Touch Instinct
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the Software), to deal
@@ -20,41 +20,23 @@
 //  THE SOFTWARE.
 //
 
-import UIKit.UITextView
-import TIUIKitCore
+public protocol InitializableViewController: InitializableViewProtocol {
 
-open class BaseInitializeableTextView: UITextView, InitializableViewProtocol {
-    public override init(frame: CGRect, textContainer: NSTextContainer?) {
-        super.init(frame: frame, textContainer: textContainer)
+    func configureBarButtons()
+}
 
-        initializeView()
+public extension InitializableViewController {
+    func initializeView() {
+        assertionFailure("Use \(String(describing: initializeController)) for UIViewController instead!")
     }
 
-    required public init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-
-        initializeView()
-    }
-
-    // MARK: - InitializableView
-
-    open func addViews() {
-        // override in subclass
-    }
-
-    open func configureLayout() {
-        // override in subclass
-    }
-
-    open func bindViews() {
-        // override in subclass
-    }
-
-    open func configureAppearance() {
-        // override in subclass
-    }
-
-    open func localize() {
-        // override in subclass
+    /// Method that should be called in viewDidLoad method of UIViewController.
+    func initializeController() {
+        addViews()
+        configureLayout()
+        configureAppearance()
+        configureBarButtons()
+        localize()
+        bindViews()
     }
 }

--- a/TIUIKitCore/Sources/ViewControllers/BaseCustomViewController.swift
+++ b/TIUIKitCore/Sources/ViewControllers/BaseCustomViewController.swift
@@ -22,7 +22,7 @@
 
 import UIKit
 
-open class BaseCustomViewController<View: UIView>: BaseInitializeableViewController {
+open class BaseCustomViewController<View: UIView>: BaseInitializableViewController {
 
     public private(set) lazy var customView = createView()
 

--- a/TIUIKitCore/Sources/ViewControllers/BaseInitializableViewController.swift
+++ b/TIUIKitCore/Sources/ViewControllers/BaseInitializableViewController.swift
@@ -20,23 +20,43 @@
 //  THE SOFTWARE.
 //
 
-public protocol InitializeableViewController: InitializableViewProtocol {
+import UIKit.UIViewController
 
-    func configureBarButtons()
-}
+open class BaseInitializableViewController: UIViewController, InitializableViewController {
 
-public extension InitializeableViewController {
-    func initializeView() {
-        assertionFailure("Use \(String(describing: initializeController)) for UIViewController instead!")
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+
+        onViewDidLoad()
     }
 
-    /// Method that should be called in viewDidLoad method of UIViewController.
-    func initializeController() {
-        addViews()
-        configureLayout()
-        configureAppearance()
-        configureBarButtons()
-        localize()
-        bindViews()
+    open func onViewDidLoad() {
+        initializeController()
+    }
+
+    // MARK: - InitializableController
+
+    open func addViews() {
+        // override in subclass
+    }
+
+    open func configureLayout() {
+        // override in subclass
+    }
+
+    open func bindViews() {
+        // override in subclass
+    }
+
+    open func configureAppearance() {
+        // override in subclass
+    }
+
+    open func localize() {
+        // override in subclass
+    }
+
+    open func configureBarButtons() {
+        // override in subclass
     }
 }

--- a/TIUIKitCore/TIUIKitCore.podspec
+++ b/TIUIKitCore/TIUIKitCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIUIKitCore'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Core UI elements: protocols, views and helpers.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/TIYandexMapUtils/TIYandexMapUtils.podspec
+++ b/TIYandexMapUtils/TIYandexMapUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TIYandexMapUtils'
-  s.version          = '1.30.0'
+  s.version          = '1.31.0'
   s.summary          = 'Set of helpers for map objects clustering and interacting using Yandex Maps SDK.'
   s.homepage         = 'https://github.com/TouchInstinct/LeadKit/tree/' + s.version.to_s + '/' + s.name
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
<img width="350" alt="Screenshot 2022-12-23 at 11 09 17" src="https://user-images.githubusercontent.com/6436245/209298260-c2d24674-49cc-4c56-a5a9-5f55a2452451.png">


```swift
let viewModel = URLInteractiveTextViewModel(text: "Вы соглашаетесь с условиями обслуживания и политикой обработки персональных данных",
                                            primaryTextStyle: .agreement(),
                                            interactiveParts: [
                                                .init(text: "условиями обслуживания", url: URL("https://policies.google.com/terms")),
                                                .init(text: "политикой обработки персональных данных", url: URL("https://policies.google.com/privacy")),
                                            ],
                                            interactivePartsStyle: .agreementLink()) {
    UIApplication.shared.open($0, options: [], completionHandler: nil)
}

let agreementTextView = URLInteractiveTextView()
agreementTextView.configure(with: viewModel)
```